### PR TITLE
Removed guava and commons-io, introduced test scope for mockito-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,9 @@
             <version>1.0.1</version>
         </dependency>
         <dependency>
-            <artifactId>guava</artifactId>
-            <groupId>com.google.guava</groupId>
-            <type>jar</type>
-            <version>14.0.1</version>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -86,19 +85,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.5.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/adyen/Util/HMACValidator.java
+++ b/src/main/java/com/adyen/Util/HMACValidator.java
@@ -1,7 +1,5 @@
 package com.adyen.Util;
 
-import com.google.common.io.BaseEncoding;
-
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.Charset;
@@ -10,6 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedMap;
 
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Hex;
+
 public class HMACValidator {
     public final static String HMAC_SHA256_ALGORITHM = "HmacSHA256";
     public final static Charset C_UTF8 = Charset.forName("UTF8");
@@ -17,7 +18,7 @@ public class HMACValidator {
     // To calculate the HMAC SHA-256
     public String calculateHMAC(String data, String key) throws java.security.SignatureException {
         try {
-            byte[] rawKey = BaseEncoding.base16().decode(key);
+            byte[] rawKey = Hex.decodeHex(key.toCharArray());
             // Create an hmac_sha256 key from the raw key bytes
             SecretKeySpec signingKey = new SecretKeySpec(rawKey, HMAC_SHA256_ALGORITHM);
 
@@ -31,7 +32,7 @@ public class HMACValidator {
             byte[] rawHmac = mac.doFinal(data.getBytes(C_UTF8));
 
             // Base64-encode the hmac
-            return BaseEncoding.base64().encode(rawHmac);
+            return new String(Base64.encodeBase64(rawHmac));
 
         } catch (Exception e) {
             throw new SignatureException("Failed to generate HMAC : " + e.getMessage());

--- a/src/test/java/com/adyen/BaseTest.java
+++ b/src/test/java/com/adyen/BaseTest.java
@@ -7,9 +7,11 @@ import com.adyen.model.*;
 import com.adyen.model.additionalData.InvoiceLine;
 import com.adyen.model.modification.AbstractModificationRequest;
 import com.adyen.model.modification.CaptureRequest;
-import org.apache.commons.io.IOUtils;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
@@ -69,7 +71,15 @@ public class BaseTest {
 
         ClassLoader classLoader = getClass().getClassLoader();
         try {
-            result = IOUtils.toString(classLoader.getResourceAsStream(fileName));
+            byte[] buffer = new byte[1024];
+            int length;
+            InputStream fileStream = classLoader.getResourceAsStream(fileName);
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            while ((length = fileStream.read(buffer)) != -1)
+            {
+                outputStream.write(buffer, 0, length);
+            }
+            result = outputStream.toString(StandardCharsets.UTF_8.name());
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Hi, I found that guava is used only to encode/decode data and appears only in one place (see changes in HMACValidator.java). This code can be easily replaced by methods from commons-codec which is also on classpath.

In addition I removed dependency to commons-io because reading stream to String can be done efficiently in plain Java (see changes in BaseTest.java). 

Last thing in this pull request is test scope for mockito-core.

All this changes reduced size of generated jar file from 6.5MB to 1.1MB, functionality remains unchanged.