### PR TITLE
Correction on return of exception (method authorise of Payment). 

### DIFF
--- a/src/main/java/com/adyen/service/Payment.java
+++ b/src/main/java/com/adyen/service/Payment.java
@@ -48,8 +48,6 @@ public class Payment extends Service {
      * POST /authorise API call
      *
      * @param paymentRequest
-     * @return
-     * @throws Exception
      */
     public PaymentResult authorise(PaymentRequest paymentRequest) throws ApiException, IOException {
         String jsonRequest = GSON.toJson(paymentRequest);

--- a/src/main/java/com/adyen/service/Payment.java
+++ b/src/main/java/com/adyen/service/Payment.java
@@ -25,9 +25,12 @@ import com.adyen.Service;
 import com.adyen.model.PaymentRequest;
 import com.adyen.model.PaymentRequest3d;
 import com.adyen.model.PaymentResult;
+import com.adyen.service.exception.ApiException;
 import com.adyen.service.resource.payment.Authorise;
 import com.adyen.service.resource.payment.Authorise3D;
 import com.google.gson.reflect.TypeToken;
+
+import java.io.IOException;
 
 public class Payment extends Service {
 
@@ -48,7 +51,7 @@ public class Payment extends Service {
      * @return
      * @throws Exception
      */
-    public PaymentResult authorise(PaymentRequest paymentRequest) throws Exception {
+    public PaymentResult authorise(PaymentRequest paymentRequest) throws ApiException, IOException {
         String jsonRequest = GSON.toJson(paymentRequest);
 
         String jsonResult = authorise.request(jsonRequest);


### PR DESCRIPTION
**Description**
The generic exception was changed to a specific exception called ApiException. This change was necessary because the generic exception return was hiding the returned error values.

**Tested scenarios**
Without this correction the exception of  authorise was returning just a com.adyen.service.exception.ApiException: HTTP Exception.


