### PR TITLE
Make RefundRequest.modificationAmount() return RefundRequest

### DIFF
--- a/src/main/java/com/adyen/model/modification/RefundRequest.java
+++ b/src/main/java/com/adyen/model/modification/RefundRequest.java
@@ -29,7 +29,7 @@ public class RefundRequest extends AbstractModificationRequest<RefundRequest> {
     @SerializedName("modificationAmount")
     private Amount modificationAmount = null;
 
-    public AbstractModificationRequest modificationAmount(Amount modificationAmount) {
+    public RefundRequest modificationAmount(Amount modificationAmount) {
         this.modificationAmount = modificationAmount;
         return this;
     }


### PR DESCRIPTION
In `RefundRequest` all chaining methods returns `RefundRequest` except for `modificationAmount`. It should also return `RefundRequest` instead of `AbstractModificationRequest`.