### PR TITLE
Make modificationAmount() return RefundRequest and CaptureRequest

### DIFF
--- a/src/main/java/com/adyen/model/modification/CaptureRequest.java
+++ b/src/main/java/com/adyen/model/modification/CaptureRequest.java
@@ -32,7 +32,7 @@ public class CaptureRequest extends AbstractModificationRequest<CaptureRequest> 
     @SerializedName("modificationAmount")
     private Amount modificationAmount = null;
 
-    public AbstractModificationRequest modificationAmount(Amount modificationAmount) {
+    public CaptureRequest modificationAmount(Amount modificationAmount) {
         this.modificationAmount = modificationAmount;
         return this;
     }

--- a/src/main/java/com/adyen/model/modification/RefundRequest.java
+++ b/src/main/java/com/adyen/model/modification/RefundRequest.java
@@ -29,7 +29,7 @@ public class RefundRequest extends AbstractModificationRequest<RefundRequest> {
     @SerializedName("modificationAmount")
     private Amount modificationAmount = null;
 
-    public AbstractModificationRequest modificationAmount(Amount modificationAmount) {
+    public RefundRequest modificationAmount(Amount modificationAmount) {
         this.modificationAmount = modificationAmount;
         return this;
     }

--- a/src/test/java/com/adyen/BaseTest.java
+++ b/src/test/java/com/adyen/BaseTest.java
@@ -21,6 +21,7 @@
 package com.adyen;
 
 import com.adyen.Util.DateUtil;
+import com.adyen.Util.Util;
 import com.adyen.enums.VatCategory;
 import com.adyen.httpclient.HTTPClientException;
 import com.adyen.httpclient.HttpURLConnectionClient;
@@ -28,6 +29,7 @@ import com.adyen.model.*;
 import com.adyen.model.additionalData.InvoiceLine;
 import com.adyen.model.modification.AbstractModificationRequest;
 import com.adyen.model.modification.CaptureRequest;
+import com.adyen.model.modification.RefundRequest;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -235,5 +237,11 @@ public class BaseTest {
         captureRequest.fillAmount("15.00", "EUR");
 
         return captureRequest;
+    }
+
+    protected RefundRequest createRefundRequest() {
+        Amount amount = Util.createAmount("15.00", "EUR");
+
+        return createBaseModificationRequest(new RefundRequest()).modificationAmount(amount);
     }
 }

--- a/src/test/java/com/adyen/ModificationTest.java
+++ b/src/test/java/com/adyen/ModificationTest.java
@@ -98,7 +98,7 @@ public class ModificationTest extends BaseTest {
         Client client = createMockClientFromFile("mocks/refund-received.json");
         Modification modification = new Modification(client);
 
-        RefundRequest refundRequest = createBaseModificationRequest(new RefundRequest());
+        RefundRequest refundRequest = createRefundRequest();
 
         ModificationResult modificationResult = modification.refund(refundRequest);
         assertEquals(ModificationResult.ResponseEnum.REFUND_RECEIVED_, modificationResult.getResponse());


### PR DESCRIPTION
In `RefundRequest` and `CaptureRequest` all chaining methods returns `RefundRequest` and `CaptureRequest` respectively except for `modificationAmount` (it returns `AbstractModificationRequest` in both classes).

This is a follow up to [this PR](https://github.com/Adyen/adyen-java-api-library/pull/114). As @lancergr requested, applied the changes to `CaptureRequest` too.