### PR TITLE
BugFix Multibanco Null check added

### DIFF
--- a/src/main/java/com/adyen/model/checkout/PaymentsResponse.java
+++ b/src/main/java/com/adyen/model/checkout/PaymentsResponse.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import com.adyen.Util.DateUtil;
 import com.adyen.model.FraudResult;
 import com.google.gson.TypeAdapter;
@@ -37,7 +36,6 @@ import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-
 import static com.adyen.constants.ApiConstants.AdditionalData.AUTH_CODE;
 import static com.adyen.constants.ApiConstants.AdditionalData.AVS_RESULT;
 import static com.adyen.constants.ApiConstants.AdditionalData.BOLETO_BARCODE_REFERENCE;
@@ -49,13 +47,13 @@ import static com.adyen.constants.ApiConstants.AdditionalData.CARD_BIN;
 import static com.adyen.constants.ApiConstants.AdditionalData.CARD_HOLDER_NAME;
 import static com.adyen.constants.ApiConstants.AdditionalData.CARD_SUMMARY;
 import static com.adyen.constants.ApiConstants.AdditionalData.EXPIRY_DATE;
+import static com.adyen.constants.ApiConstants.AdditionalData.MULTIBANCO_AMOUNT;
+import static com.adyen.constants.ApiConstants.AdditionalData.MULTIBANCO_DEADLINE;
+import static com.adyen.constants.ApiConstants.AdditionalData.MULTIBANCO_ENTITY;
+import static com.adyen.constants.ApiConstants.AdditionalData.MULTIBANCO_REFERENCE;
 import static com.adyen.constants.ApiConstants.AdditionalData.PAYMENT_METHOD;
 import static com.adyen.constants.ApiConstants.AdditionalData.THREE_D_AUTHENTICATED;
 import static com.adyen.constants.ApiConstants.AdditionalData.THREE_D_OFFERERED;
-import static com.adyen.constants.ApiConstants.AdditionalData.MULTIBANCO_ENTITY;
-import static com.adyen.constants.ApiConstants.AdditionalData.MULTIBANCO_AMOUNT;
-import static com.adyen.constants.ApiConstants.AdditionalData.MULTIBANCO_REFERENCE;
-import static com.adyen.constants.ApiConstants.AdditionalData.MULTIBANCO_DEADLINE;
 
 /**
  * PaymentsResponse
@@ -536,6 +534,9 @@ public class PaymentsResponse {
     }
 
     public BigDecimal getMultibancoAmount() {
+        if (getAdditionalDataByKey(MULTIBANCO_AMOUNT) == null) {
+            return null;
+        }
         return new BigDecimal(getAdditionalDataByKey(MULTIBANCO_AMOUNT));
     }
 

--- a/src/test/java/com/adyen/CheckoutTest.java
+++ b/src/test/java/com/adyen/CheckoutTest.java
@@ -20,6 +20,14 @@
  */
 package com.adyen;
 
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import org.junit.Assert;
+import org.junit.Test;
 import com.adyen.model.Amount;
 import com.adyen.model.checkout.DefaultPaymentMethodDetails;
 import com.adyen.model.checkout.PaymentMethodDetails;
@@ -34,15 +42,6 @@ import com.adyen.model.checkout.PaymentsRequest;
 import com.adyen.model.checkout.PaymentsResponse;
 import com.adyen.service.Checkout;
 import com.google.gson.annotations.SerializedName;
-import org.junit.Test;
-
-import java.math.BigDecimal;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
-
 import static com.adyen.Client.LIB_NAME;
 import static com.adyen.Client.LIB_VERSION;
 import static com.adyen.enums.Environment.LIVE;
@@ -341,6 +340,30 @@ public class CheckoutTest extends BaseTest {
                 + "    }\n"
                 + "  }\n"
                 + "}",jsonRequest );
+    }
+
+    @Test
+    public void TestPaymentResponseDate() {
+        PaymentsResponse paymentsResponse = new PaymentsResponse();
+        try {
+            Date expiryDate = paymentsResponse.getExpiryDate();
+            assertEquals(null, expiryDate);
+        } catch (Exception ex) {
+
+            Assert.fail("multibanco date throw Exception");
+        }
+    }
+
+    @Test
+    public void TestPaymentResponseMultibanco() {
+        PaymentsResponse paymentsResponse = new PaymentsResponse();
+        try {
+            BigDecimal multibancoAmount = paymentsResponse.getMultibancoAmount();
+            assertEquals(null, multibancoAmount);
+        } catch (Exception ex) {
+
+            Assert.fail("multibanco amount throw Exception");
+        }
     }
 
     /**


### PR DESCRIPTION
**Description**
Multibanco amount null check before cast to BigDecimal

**Tested scenarios**
Empty multibanco amount returns null and not throw exception  

