### PR TITLE
Add `AuthenticationFinished` resultCode to `ResultCodeEnum`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.adyen</groupId>
     <artifactId>adyen-java-api-library</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <name>Adyen Java API Library</name>
     <description>Adyen API Client Library for Java</description>
     <url>https://github.com/adyen/adyen-java-api-library</url>

--- a/src/main/java/com/adyen/model/PaymentResult.java
+++ b/src/main/java/com/adyen/model/PaymentResult.java
@@ -93,7 +93,10 @@ public class PaymentResult {
         IDENTIFYSHOPPER("IdentifyShopper"),
 
         @SerializedName("ChallengeShopper")
-        CHALLENGESHOPPER("ChallengeShopper");
+        CHALLENGESHOPPER("ChallengeShopper"),
+
+        @SerializedName("AuthenticationFinished")
+        AUTHENTICATIONFINISHED("AuthenticationFinished");
 
         private String value;
 

--- a/src/test/java/com/adyen/PaymentResultTest.java
+++ b/src/test/java/com/adyen/PaymentResultTest.java
@@ -1,0 +1,18 @@
+package com.adyen;
+
+import com.adyen.model.PaymentResult;
+import com.google.gson.Gson;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class PaymentResultTest extends BaseTest {
+
+    @Test
+    public void TestAuthenticationFinishedResultCodeDeserialization() {
+        Gson gson = new Gson();
+        String response = "{\"resultCode\": \"AuthenticationFinished\"}";
+        PaymentResult result = gson.fromJson(response, PaymentResult.class);
+        assertNotNull(result.getResultCode());
+    }
+}


### PR DESCRIPTION
**Description**
Unable to retrieve result code `AuthenticationFinished` from API response

**Tested scenarios**
Without change, test provided fails. With change, test passes

**Fixed issue**: #197
