### PR TITLE
Adding travis_wait to mvn install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ jdk:
   - oraclejdk8
   - openjdk7
 
-install: mvn install -Dgpg.skip=true
+#travis_wait : avoid time out
+install: travis_wait mvn install -Dgpg.skip=true
 
 sudo: false
 


### PR DESCRIPTION

**Description**
Why ?
Building such big APIs as Adyen APIs   can take a lot of time.  **It's possible to get a time out.**
[Here](https://github.com/4hwc/4HWCAutonomousCar/commit/96c6396d444f0364150241c5bed3e0b9fc7ba5c8) , I got a time out due to generating javadoc. 
Then, I decided to add **travis_wait** and it works pretty well.

Official docs : https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

