### PR TITLE
[PW-2034] Add http response headers to ApiException

### DIFF
--- a/src/main/java/com/adyen/service/Resource.java
+++ b/src/main/java/com/adyen/service/Resource.java
@@ -77,7 +77,7 @@ public class Resource {
             return clientInterface.request(this.endpoint, json, config, this.service.isApiKeyRequired(), requestOptions);
         } catch (HTTPClientException e) {
             responseBody = e.getResponseBody();
-            apiException = new ApiException(e.getMessage(), e.getCode());
+            apiException = new ApiException(e.getMessage(), e.getCode(), e.getResponseHeaders());
         }
 
         // Enhance ApiException with more info from JSON payload

--- a/src/main/java/com/adyen/service/exception/ApiException.java
+++ b/src/main/java/com/adyen/service/exception/ApiException.java
@@ -20,6 +20,8 @@
  */
 package com.adyen.service.exception;
 
+import java.util.List;
+import java.util.Map;
 import com.adyen.model.ApiError;
 
 /**
@@ -32,9 +34,17 @@ public class ApiException extends Exception {
     //HTTP status code
     private int statusCode;
 
+    private Map<String, List<String>> responseHeaders;
+
     public ApiException(String message, int statusCode) {
         super(message);
         this.statusCode = statusCode;
+    }
+
+    public ApiException(String message, int statusCode, Map<String, List<String>> responseHeaders) {
+        super(message);
+        this.statusCode = statusCode;
+        this.responseHeaders = responseHeaders;
     }
 
     public ApiError getError() {
@@ -53,6 +63,9 @@ public class ApiException extends Exception {
         this.statusCode = statusCode;
     }
 
+    public Map<String, List<String>> getResponseHeaders() {
+        return responseHeaders;
+    }
     @Override
     public String toString() {
         return "ApiException{" + "error=" + error + ", statusCode=" + statusCode + ", message=" + getMessage() + '}';

--- a/src/main/java/com/adyen/service/exception/ApiException.java
+++ b/src/main/java/com/adyen/service/exception/ApiException.java
@@ -68,6 +68,6 @@ public class ApiException extends Exception {
     }
     @Override
     public String toString() {
-        return "ApiException{" + "error=" + error + ", statusCode=" + statusCode + ", message=" + getMessage() + '}';
+        return "ApiException{" + "error=" + error + ", statusCode=" + statusCode + ", message=" + getMessage() + ", responseHeaders=" + getResponseHeaders() + "}";
     }
 }


### PR DESCRIPTION
**Description**
This story is about to access the Transient-Error header value through http client exception. The response returns an HTTP 409 – Conflict status with the error code 704: "request already processed or in progress" but not any http headers.
For information about the Transient-Error check [docs](https://docs.adyen.com/development-resources/api-idempotency#transient-errors)


**Tested scenarios**
Internal e2e test /payments making two transactions with the same idempotency key.

**Fixed issue**:   #284 
