### PR TITLE
Update BarcodeOuput to reflect API doc

### DIFF
--- a/src/main/java/com/adyen/model/nexo/BarcodeType.java
+++ b/src/main/java/com/adyen/model/nexo/BarcodeType.java
@@ -19,7 +19,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="Code25"/&gt;
  *     &lt;enumeration value="Code128"/&gt;
  *     &lt;enumeration value="PDF417"/&gt;
- *     &lt;enumeration value="QRCODE"/&gt;
+ *     &lt;enumeration value="QRCode"/&gt;
  *   &lt;/restriction&gt;
  * &lt;/simpleType&gt;
  * </pre>
@@ -60,7 +60,8 @@ public enum BarcodeType {
     /**
      * Qrcode barcode type.
      */
-    QRCODE("QRCODE");
+    @XmlEnumValue("QRCode")
+    QRCODE("QRCode");
     private final String value;
 
     BarcodeType(String v) {

--- a/src/main/java/com/adyen/model/nexo/OutputBarcode.java
+++ b/src/main/java/com/adyen/model/nexo/OutputBarcode.java
@@ -4,7 +4,6 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
 
 
 /**

--- a/src/main/java/com/adyen/model/nexo/OutputBarcode.java
+++ b/src/main/java/com/adyen/model/nexo/OutputBarcode.java
@@ -26,15 +26,15 @@ import javax.xml.bind.annotation.XmlValue;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "OutputBarcode", propOrder = {
-        "value"
+        "barcodeValue"
 })
 public class OutputBarcode {
 
     /**
      * The Value.
      */
-    @XmlValue
-    protected String value;
+    @XmlAttribute(name = "BarcodeValue")
+    protected String barcodeValue;
     /**
      * The Barcode.
      */
@@ -47,16 +47,16 @@ public class OutputBarcode {
      * @return possible      object is     {@link String }
      */
     public String getValue() {
-        return value;
+        return barcodeValue;
     }
 
     /**
-     * Sets the value of the value property.
+     * Sets the value of the barcodeValue property.
      *
-     * @param value allowed object is     {@link String }
+     * @param barcodeValue allowed object is     {@link String }
      */
-    public void setValue(String value) {
-        this.value = value;
+    public void setBarcodeValue(String barcodeValue) {
+        this.barcodeValue = barcodeValue;
     }
 
     /**


### PR DESCRIPTION
**Description**
This PR addresses two issues:
- Changing the BarcodeType-ENUM from `QRCODE` to `QRCode`
- Changing the barcode's value to `barcodeValue`

**Tested scenarios**
None, since the only terminal available to me, the V400m, apparently doesn't support `DisplayRequest` calls.

However, these fixes take the error messages from "Unexpected field value" and "field barcodeValue missing" to "Unsupported output format" - which seems like an improvement?

**Fixed issue**:  No issue opened
