### PR TITLE
Added missing messageVersion field to ThreeDS2Result

### DIFF
--- a/src/main/java/com/adyen/model/checkout/ThreeDS2Result.java
+++ b/src/main/java/com/adyen/model/checkout/ThreeDS2Result.java
@@ -49,6 +49,9 @@ public class ThreeDS2Result {
     @SerializedName("dsTransID")
     private String dsTransID;
 
+    @SerializedName("messageVersion")
+    private String messageVersion;
+
     /**
      * The transStatusReason value as defined in the 3D Secure 2 specification.
      *
@@ -175,6 +178,19 @@ public class ThreeDS2Result {
         return this;
     }
 
+    public String getMessageVersion() {
+        return messageVersion;
+    }
+
+    public void setMessageVersion(String messageVersion) {
+        this.messageVersion = messageVersion;
+    }
+
+    public ThreeDS2Result messageVersion(String messageVersion) {
+        this.messageVersion = messageVersion;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -190,7 +206,8 @@ public class ThreeDS2Result {
                 Objects.equals(eci, that.eci) &&
                 Objects.equals(timestamp, that.timestamp) &&
                 Objects.equals(threeDSServerTransID, that.threeDSServerTransID) &&
-                Objects.equals(dsTransID, that.dsTransID);
+                Objects.equals(dsTransID, that.dsTransID) &&
+                Objects.equals(messageVersion, that.messageVersion);
     }
 
     @Override
@@ -209,6 +226,7 @@ public class ThreeDS2Result {
         sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
         sb.append("    threeDSServerTransID: ").append(toIndentedString(threeDSServerTransID)).append("\n");
         sb.append("    dsTransID: ").append(toIndentedString(dsTransID)).append("\n");
+        sb.append("    messageVersion: ").append(toIndentedString(messageVersion)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/src/main/java/com/adyen/model/checkout/ThreeDS2Result.java
+++ b/src/main/java/com/adyen/model/checkout/ThreeDS2Result.java
@@ -212,7 +212,7 @@ public class ThreeDS2Result {
 
     @Override
     public int hashCode() {
-        return Objects.hash(transStatusReason, transStatus, authenticationValue, eci, timestamp, threeDSServerTransID, dsTransID);
+        return Objects.hash(transStatusReason, transStatus, authenticationValue, eci, timestamp, threeDSServerTransID, dsTransID, messageVersion);
     }
 
     @Override

--- a/src/test/java/com/adyen/CheckoutTest.java
+++ b/src/test/java/com/adyen/CheckoutTest.java
@@ -456,6 +456,22 @@ public class CheckoutTest extends BaseTest {
     }
 
     @Test
+    public void TestPaymentResponseAuthenticationFinished() throws Exception {
+        Client client = createMockClientFromFile("mocks/checkout/payments-3ds2-authentication-finished.json");
+        Checkout checkout = new Checkout(client);
+        PaymentsRequest paymentsRequest = createPaymentsCheckoutRequest();
+        PaymentsResponse paymentsResponse = checkout.payments(paymentsRequest);
+        assertEquals(PaymentsResponse.ResultCodeEnum.AUTHENTICATIONFINISHED, paymentsResponse.getResultCode());
+        assertNotNull(paymentsResponse.getThreeDS2Result());
+        assertNotNull(paymentsResponse.getThreeDS2Result().getAuthenticationValue());
+        assertNotNull(paymentsResponse.getThreeDS2Result().getDsTransID());
+        assertNotNull(paymentsResponse.getThreeDS2Result().getEci());
+        assertNotNull(paymentsResponse.getThreeDS2Result().getMessageVersion());
+        assertNotNull(paymentsResponse.getThreeDS2Result().getThreeDSServerTransID());
+        assertNotNull(paymentsResponse.getThreeDS2Result().getTransStatus());
+    }
+
+    @Test
     public void TestPaymentLinksSuccess() throws Exception {
         Client client = createMockClientFromFile("mocks/checkout/payment-links-success.json");
         Checkout checkout = new Checkout(client);

--- a/src/test/resources/mocks/checkout/payments-3ds2-authentication-finished.json
+++ b/src/test/resources/mocks/checkout/payments-3ds2-authentication-finished.json
@@ -1,0 +1,36 @@
+{
+  "pspReference": "882563360573365D",
+  "resultCode": "AuthenticationFinished",
+  "threeDS2Result": {
+    "authenticationValue": "QURZRU4gM0RTMiBURVNUIENBVlY=",
+    "dsTransID": "64f18dcc-ad7f-4879-b7b9-2c0e0e3b2a33",
+    "eci": "05",
+    "messageVersion": "2.1.0",
+    "threeDSServerTransID": "6e8833e6-d591-4f54-86f9-93755533e869",
+    "transStatus": "Y"
+  },
+  "additionalData": {
+    "fraudResultType": "GREEN",
+    "fraudManualReview": "false",
+    "issuerCountry": "unknown",
+    "cardBin": "421234",
+    "paymentMethod": "visa",
+    "paymentMethodVariant": "visa"
+  },
+  "fraudResult": {
+    "accountScore": 25,
+    "results": [{
+      "FraudCheckResult": {
+        "accountScore": 8,
+        "checkId": 2,
+        "name": "CardChunkUsage"
+      }
+    }, {
+      "FraudCheckResult": {
+        "accountScore": 5,
+        "checkId": 3,
+        "name": "PaymentDetailUsage"
+      }
+    }]
+  }
+}


### PR DESCRIPTION
**Description**
com.adyen.model.checkout.ThreeDS2Result has field messageVersion missing. Field has been available since at least July. We had been processing it already since then.

**Tested scenarios**
N/A

**Fixed issue**:  
Issue has not been logged (as far as I know) 
