### PR TITLE
Including all notification codes as constants

### DIFF
--- a/src/main/java/com/adyen/model/notification/NotificationRequestItem.java
+++ b/src/main/java/com/adyen/model/notification/NotificationRequestItem.java
@@ -32,14 +32,38 @@ import com.google.gson.annotations.SerializedName;
 public class NotificationRequestItem {
     public static final String EVENT_CODE_AUTHORISATION = "AUTHORISATION";
 
-    //Event codes
+    //Standard Event codes
+    public static final String EVENT_CODE_AUTHORISATION_ADJUSTMENT = "AUTHORISATION_ADJUSTMENT";
     public static final String EVENT_CODE_CANCELLATION = "CANCELLATION";
     public static final String EVENT_CODE_REFUND = "REFUND";
     public static final String EVENT_CODE_CANCEL_OR_REFUND = "CANCEL_OR_REFUND";
     public static final String EVENT_CODE_CAPTURE = "CAPTURE";
     public static final String EVENT_CODE_CAPTURE_FAILED = "CAPTURE_FAILED";
     public static final String EVENT_CODE_REFUND_FAILED = "REFUND_FAILED";
+    public static final String EVENT_CODE_REFUND_WITH_DATA = "REFUND_WITH_DATA";
     public static final String EVENT_CODE_REFUNDED_REVERSED = "REFUNDED_REVERSED";
+    public static final String EVENT_CODE_HANDLED_EXTERNALLY = "HANDLED_EXTERNALLY";
+    public static final String EVENT_CODE_ORDER_OPENED = "ORDER_OPENED";
+    public static final String EVENT_CODE_ORDER_CLOSED = "ORDER_CLOSED";
+    public static final String EVENT_CODE_PENDING = "PENDING";
+    public static final String EVENT_CODE_PROCESS_RETRY = "PROCESS_RETRY";
+    public static final String EVENT_CODE_REPORT_AVAILABLE = "REPORT_AVAILABLE";
+    public static final String EVENT_CODE_VOID_PENDING_REFUND = "VOID_PENDING_REFUND";
+
+    //Dispute Event Codes
+    public static final String EVENT_CODE_CHARGEBACK = "CHARGEBACK";
+    public static final String EVENT_CODE_CHARGEBACK_REVERSED = "CHARGEBACK_REVERSED";
+    public static final String EVENT_CODE_NOTIFICATION_OF_CHARGEBACK = "NOTIFICATION_OF_CHARGEBACK";
+    public static final String EVENT_CODE_NOTIFICATION_OF_FRAUD = "NOTIFICATION_OF_FRAUD";
+    public static final String EVENT_CODE_PREARBITRATION_LOST = "PREARBITRATION_LOST";
+    public static final String EVENT_CODE_PREARBITRATION_WON = "PREARBITRATION_WON";
+    public static final String EVENT_CODE_REQUEST_FOR_INFORMATION = "REQUEST_FOR_INFORMATION";
+    public static final String EVENT_CODE_SECOND_CHARGEBACK = "SECOND_CHARGEBACK";
+
+    //Payout Event Codes
+    public static final String EVENT_CODE_PAYOUT_EXPIRE = "PAYOUT_EXPIRE";
+    public static final String EVENT_CODE_PAYOUT_DECLINE = "PAYOUT_DECLINE";
+    public static final String EVENT_CODE_PAYOUT_THIRDPARTY = "PAYOUT_THIRDPARTY";
     public static final String EVENT_CODE_PAIDOUT_REVERSED = "PAIDOUT_REVERSED";
 
     //Additional Data

--- a/src/test/resources/mocks/notification/cancellation-true.json
+++ b/src/test/resources/mocks/notification/cancellation-true.json
@@ -1,0 +1,21 @@
+{
+  "live":"false",
+  "notificationItems":[
+    {
+      "NotificationRequestItem":{
+        "amount":{
+          "currency":"EUR",
+          "value":500
+        },
+        "eventCode":"CANCELLATION",
+        "eventDate":"2018-03-05T09:08:05+01:00",
+        "merchantAccountCode":"YOUR_MERCHANT_ACCOUNT",
+        "originalReference":"8313547924770610",
+        "paymentMethod":"mc",
+        "pspReference":"8412534564722331",
+        "reason":"",
+        "success":"true"
+      }
+    }
+  ]
+}

--- a/src/test/resources/mocks/notification/chargeback.json
+++ b/src/test/resources/mocks/notification/chargeback.json
@@ -1,0 +1,27 @@
+{
+  "live":"true",
+  "notificationItems":[
+    {
+      "NotificationRequestItem":{
+        "additionalData":{
+          "chargebackReasonCode":"10.4",
+          "modificationMerchantReferences":"",
+          "chargebackSchemeCode":"visa"
+        },
+        "amount":{
+          "currency":"EUR",
+          "value":1000
+        },
+        "eventCode":"CHARGEBACK",
+        "eventDate":"2018-03-23T13:55:31+01:00",
+        "merchantAccountCode":"TestMerchant",
+        "merchantReference":"XXXXXXXXXX",
+        "originalReference":"9913333333333333",
+        "paymentMethod":"visa",
+        "pspReference":"9915555555555555",
+        "reason":"Other Fraud-Card Absent Environment",
+        "success":"true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Description**
- Creating constantes for all notification codes, got it from https://docs.adyen.com/development-resources/notifications/understand-notifications#event-codes
- Dedup of test code at NotificationTest class

**Tested scenarios**
Parser of cancellation and chargeback events

**Fixed issue**:  
https://github.com/Adyen/adyen-java-api-library/issues/307

**Question**
Do really make sense create tests for every event code? Looking at `NotificationRequestItem.class`, sounds like you are just testing GSON and the contract of the event.
If it's important to test every case, could you guys provide JSON examples? It is hard to find examples for every event at the site.
