### PR TITLE
PW-2192: Added tests with encrypted card details

### DIFF
--- a/src/test/java/com/adyen/CheckoutTest.java
+++ b/src/test/java/com/adyen/CheckoutTest.java
@@ -82,6 +82,19 @@ public class CheckoutTest extends BaseTest {
     }
 
     /**
+     * Test success flow for
+     * POST /payments
+     */
+    @Test
+    public void TestEncryptedPaymentsSuccessMocked() throws Exception {
+        Client client = createMockClientFromFile("mocks/checkout/payments-encrypted-success.json");
+        Checkout checkout = new Checkout(client);
+        PaymentsRequest paymentsRequest = createEncryptedPaymentsCheckoutRequest();
+        PaymentsResponse paymentsResponse = checkout.payments(paymentsRequest);
+        assertEquals("883586864229293H", paymentsResponse.getPspReference());
+    }
+
+    /**
      * Test error flow for
      * POST /payments
      */
@@ -259,6 +272,62 @@ public class CheckoutTest extends BaseTest {
                 + "    \"expiryYear\": \"2018\",\n"
                 + "    \"holderName\": \"John Smith\",\n"
                 + "    \"cvc\": \"737\"\n"
+                + "  },\n"
+                + "  \"reference\": \"Your order number\",\n"
+                + "  \"returnUrl\": \"https://your-company.com/...\",\n"
+                + "  \"applicationInfo\": {\n"
+                + "    \"adyenLibrary\": {\n"
+                + "      \"name\": \"" + LIB_NAME + "\",\n"
+                + "      \"version\": \"" + LIB_VERSION + "\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}", jsonRequest);
+
+        TestPaymentMethodDetails testPaymentMethodDetails = new TestPaymentMethodDetails();
+        testPaymentMethodDetails.setType("testType");
+        testPaymentMethodDetails.setTestValue("testValue");
+        paymentsRequest.setPaymentMethod(testPaymentMethodDetails);
+
+        jsonRequest = PRETTY_PRINT_GSON.toJson(paymentsRequest);
+        assertEquals("{\n"
+                + "  \"amount\": {\n"
+                + "    \"value\": 1000,\n"
+                + "    \"currency\": \"USD\"\n"
+                + "  },\n"
+                + "  \"merchantAccount\": \"MagentoMerchantTest\",\n"
+                + "  \"paymentMethod\": {\n"
+                + "    \"testKey\": \"testValue\",\n"
+                + "    \"type\": \"testType\"\n"
+                + "  },\n"
+                + "  \"reference\": \"Your order number\",\n"
+                + "  \"returnUrl\": \"https://your-company.com/...\",\n"
+                + "  \"applicationInfo\": {\n"
+                + "    \"adyenLibrary\": {\n"
+                + "      \"name\": \"" + LIB_NAME + "\",\n"
+                + "      \"version\": \"" + LIB_VERSION + "\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}", jsonRequest);
+    }
+
+    @Test
+    public void TestEncryptedPaymentMethodDetails() {
+        PaymentsRequest paymentsRequest = createEncryptedPaymentsCheckoutRequest();
+        String jsonRequest = PRETTY_PRINT_GSON.toJson(paymentsRequest);
+
+        assertEquals("{\n"
+                + "  \"amount\": {\n"
+                + "    \"value\": 1000,\n"
+                + "    \"currency\": \"USD\"\n"
+                + "  },\n"
+                + "  \"merchantAccount\": \"MagentoMerchantTest\",\n"
+                + "  \"paymentMethod\": {\n"
+                + "    \"type\": \"scheme\",\n"
+                + "    \"holderName\": \"John Smith\",\n"
+                + "    \"encryptedCardNumber\": \"test_4111111111111111\",\n"
+                + "    \"encryptedExpiryMonth\": \"test_03\",\n"
+                + "    \"encryptedExpiryYear\": \"test_2030\",\n"
+                + "    \"encryptedSecurityCode\": \"test_737\"\n"
                 + "  },\n"
                 + "  \"reference\": \"Your order number\",\n"
                 + "  \"returnUrl\": \"https://your-company.com/...\",\n"
@@ -550,7 +619,7 @@ public class CheckoutTest extends BaseTest {
     }
 
     /**
-     * Returns a sample PaymentSessionRequest opbject with test data
+     * Returns a sample PaymentSessionRequest object with test data
      */
 
     protected PaymentSessionRequest createPaymentSessionRequest() {
@@ -565,7 +634,7 @@ public class CheckoutTest extends BaseTest {
     }
 
     /**
-     * Returns a sample PaymentsRequest opbject with test data
+     * Returns a sample PaymentsRequest object with test data
      */
     protected PaymentsRequest createPaymentsCheckoutRequest() {
         PaymentsRequest paymentsRequest = new PaymentsRequest();
@@ -579,6 +648,23 @@ public class CheckoutTest extends BaseTest {
 
         return paymentsRequest;
     }
+
+    /**
+     * Returns a sample Encrypted PaymentsRequest opbject with test data
+     */
+    protected PaymentsRequest createEncryptedPaymentsCheckoutRequest() {
+        PaymentsRequest paymentsRequest = new PaymentsRequest();
+
+        paymentsRequest.setReference("Your order number");
+        paymentsRequest.setAmount(createAmountObject("USD", 1000L));
+        paymentsRequest.addEncryptedCardData("test_4111111111111111", "test_03", "test_2030", "test_737", "John Smith");
+
+        paymentsRequest.setReturnUrl("https://your-company.com/...");
+        paymentsRequest.setMerchantAccount("MagentoMerchantTest");
+
+        return paymentsRequest;
+    }
+
 
     /**
      * Returns a sample PaymentsDetailsRequest opbject with test data

--- a/src/test/resources/mocks/checkout/payments-encrypted-success.json
+++ b/src/test/resources/mocks/checkout/payments-encrypted-success.json
@@ -1,0 +1,79 @@
+{
+  "additionalData": {
+    "fraudResultType": "GREEN",
+    "cardHolderName": "Checkout Shopper PlaceHolder",
+    "cardSummary": "1111",
+    "fraudManualReview": "false",
+    "shopperEmail": "testmail@mail.com",
+    "expiryDate": "3/2030",
+    "shopperDetails": "retrieved",
+    "cardBin": "411111",
+    "aliasType": "Default",
+    "alias": "H167852639363479",
+    "paymentMethod": "visa",
+    "paymentMethodVariant": "visa",
+    "merchantReference": "Your order number",
+    "shopperReference": "1"
+  },
+  "fraudResult": {
+    "accountScore": 0,
+    "results": [
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 2,
+          "name": "CardChunkUsage"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 3,
+          "name": "PaymentDetailUsage"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 1,
+          "name": "PaymentDetailRefCheck"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 13,
+          "name": "IssuerRefCheck"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 15,
+          "name": "IssuingCountryReferral"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 82,
+          "name": "CustomFieldCheck"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 25,
+          "name": "CVCAuthResultCheck"
+        }
+      }
+    ]
+  },
+  "pspReference": "883586864229293H",
+  "resultCode": "Authorised",
+  "amount": {
+    "currency": "USD",
+    "value": 1000
+  },
+  "merchantReference": "Your order number"
+}


### PR DESCRIPTION
**Description**
Added tests with encrypted card details that don't need a component to be encrypted(only works on test),
for more examples see:
https://docs.adyen.com/checkout/api-only?tab=%23codeBlockitIb5_Java#step-3-make-a-payment
and the API explorer scenarios:
https://docs.adyen.com/api-explorer/#/PaymentSetupAndVerificationService/v52/payments__example_payments-card-securedfields
