### PR TITLE
Changed library version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.adyen</groupId>
   <artifactId>adyen-java-api-library</artifactId>
-  <version>7.1.0</version>
+  <version>7.0.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Latest version on maven is 7.0.1, not 7.1.0.

Description
The sdk version in the example does not exist on maven, I assume it was a typo.

Tested scenarios

Fixed issue:
