### PR TITLE
PW-2623: change the 'response' field type of ModificationResult to String

### DIFF
--- a/src/main/java/com/adyen/model/modification/ModificationResult.java
+++ b/src/main/java/com/adyen/model/modification/ModificationResult.java
@@ -47,8 +47,9 @@ public class ModificationResult {
 
 
     /**
-     * the response which indicates if the modification request has been received for processing.
+     * @deprecated As of library version 8.0.0, the response type for ModificationResult is a String
      */
+    @Deprecated
     public enum ResponseEnum {
         @SerializedName("[capture-received]")
         CAPTURE_RECEIVED_("[capture-received]"),
@@ -87,7 +88,7 @@ public class ModificationResult {
     }
 
     @SerializedName("response")
-    private ResponseEnum response = null;
+    private String response = null;
 
     @SerializedName("additionalData")
     private Map<String, String> additionalData = null;
@@ -110,7 +111,7 @@ public class ModificationResult {
         this.pspReference = pspReference;
     }
 
-    public ModificationResult response(ResponseEnum response) {
+    public ModificationResult response(String response) {
         this.response = response;
         return this;
     }
@@ -120,11 +121,11 @@ public class ModificationResult {
      *
      * @return response
      **/
-    public ResponseEnum getResponse() {
+    public String getResponse() {
         return response;
     }
 
-    public void setResponse(ResponseEnum response) {
+    public void setResponse(String response) {
         this.response = response;
     }
 

--- a/src/main/java/com/adyen/model/modification/ModificationResult.java
+++ b/src/main/java/com/adyen/model/modification/ModificationResult.java
@@ -45,48 +45,6 @@ public class ModificationResult {
     @SerializedName("splits")
     private List<Split> splits = null;
 
-
-    /**
-     * @deprecated As of library version 8.0.0, the response type for ModificationResult is a String
-     */
-    @Deprecated
-    public enum ResponseEnum {
-        @SerializedName("[capture-received]")
-        CAPTURE_RECEIVED_("[capture-received]"),
-
-        @SerializedName("[cancel-received]")
-        CANCEL_RECEIVED_("[cancel-received]"),
-
-        @SerializedName("[technical-cancel-received]")
-        TECHNICAL_CANCEL_RECEIVED_("[technical-cancel-received]"),
-
-        @SerializedName("[refund-received]")
-        REFUND_RECEIVED_("[refund-received]"),
-
-        @SerializedName("[cancelOrRefund-received]")
-        CANCELORREFUND_RECEIVED_("[cancelOrRefund-received]"),
-
-        @SerializedName("[adjustAuthorisation-received]")
-        ADJUSTAUTHORISATION_RECEIVED_("[adjustAuthorisation-received]"),
-
-        @SerializedName("[voidPendingRefund-received]")
-        VOIDPENDINGREFUND_RECEIVED_("[voidPendingRefund-received]"),
-
-        @SerializedName("[donation-received]")
-        DONATION_RECEIVED_("[donation-received]");
-
-        private String value;
-
-        ResponseEnum(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public String toString() {
-            return String.valueOf(value);
-        }
-    }
-
     @SerializedName("response")
     private String response = null;
 

--- a/src/test/java/com/adyen/ModificationTest.java
+++ b/src/test/java/com/adyen/ModificationTest.java
@@ -47,7 +47,7 @@ public class ModificationTest extends BaseTest {
         CaptureRequest captureRequest = createCaptureRequest();
 
         ModificationResult modificationResult = modification.capture(captureRequest);
-        assertEquals(ModificationResult.ResponseEnum.CAPTURE_RECEIVED_.toString(), modificationResult.getResponse());
+        assertEquals("[capture-received]", modificationResult.getResponse());
         assertEquals("test", modificationResult.getAdditionalData().get("merchantReference"));
     }
 
@@ -88,7 +88,7 @@ public class ModificationTest extends BaseTest {
         CancelOrRefundRequest cancelOrRefundRequest = createBaseModificationRequest(new CancelOrRefundRequest());
 
         ModificationResult modificationResult = modification.cancelOrRefund(cancelOrRefundRequest);
-        assertEquals(ModificationResult.ResponseEnum.CANCELORREFUND_RECEIVED_.toString(), modificationResult.getResponse());
+        assertEquals("[cancelOrRefund-received]", modificationResult.getResponse());
     }
 
     /**
@@ -104,7 +104,7 @@ public class ModificationTest extends BaseTest {
         RefundRequest refundRequest = createRefundRequest();
 
         ModificationResult modificationResult = modification.refund(refundRequest);
-        assertEquals(ModificationResult.ResponseEnum.REFUND_RECEIVED_.toString(), modificationResult.getResponse());
+        assertEquals("[refund-received]", modificationResult.getResponse());
     }
 
     /**
@@ -120,7 +120,7 @@ public class ModificationTest extends BaseTest {
         CancelRequest cancelRequest = createBaseModificationRequest(new CancelRequest());
 
         ModificationResult modificationResult = modification.cancel(cancelRequest);
-        assertEquals(ModificationResult.ResponseEnum.CANCEL_RECEIVED_.toString(), modificationResult.getResponse());
+        assertEquals("[cancel-received]", modificationResult.getResponse());
     }
 
     /**
@@ -136,7 +136,7 @@ public class ModificationTest extends BaseTest {
         VoidPendingRefundRequest voidPendingRefundRequest = createVoidPendingRefundRequest();
 
         ModificationResult modificationResult = modification.voidPendingRefund(voidPendingRefundRequest);
-        assertEquals(ModificationResult.ResponseEnum.VOIDPENDINGREFUND_RECEIVED_.toString(), modificationResult.getResponse());
+        assertEquals("[voidPendingRefund-received]", modificationResult.getResponse());
     }
 
     /**
@@ -152,6 +152,6 @@ public class ModificationTest extends BaseTest {
         DonationRequest donationRequest = createDonationRequest();
 
         ModificationResult modificationResult = modification.donate(donationRequest);
-        assertEquals(ModificationResult.ResponseEnum.DONATION_RECEIVED_.toString(), modificationResult.getResponse());
+        assertEquals("[donation-received]", modificationResult.getResponse());
     }
 }

--- a/src/test/java/com/adyen/ModificationTest.java
+++ b/src/test/java/com/adyen/ModificationTest.java
@@ -47,7 +47,7 @@ public class ModificationTest extends BaseTest {
         CaptureRequest captureRequest = createCaptureRequest();
 
         ModificationResult modificationResult = modification.capture(captureRequest);
-        assertEquals(ModificationResult.ResponseEnum.CAPTURE_RECEIVED_, modificationResult.getResponse());
+        assertEquals(ModificationResult.ResponseEnum.CAPTURE_RECEIVED_.toString(), modificationResult.getResponse());
         assertEquals("test", modificationResult.getAdditionalData().get("merchantReference"));
     }
 
@@ -88,7 +88,7 @@ public class ModificationTest extends BaseTest {
         CancelOrRefundRequest cancelOrRefundRequest = createBaseModificationRequest(new CancelOrRefundRequest());
 
         ModificationResult modificationResult = modification.cancelOrRefund(cancelOrRefundRequest);
-        assertEquals(ModificationResult.ResponseEnum.CANCELORREFUND_RECEIVED_, modificationResult.getResponse());
+        assertEquals(ModificationResult.ResponseEnum.CANCELORREFUND_RECEIVED_.toString(), modificationResult.getResponse());
     }
 
     /**
@@ -104,7 +104,7 @@ public class ModificationTest extends BaseTest {
         RefundRequest refundRequest = createRefundRequest();
 
         ModificationResult modificationResult = modification.refund(refundRequest);
-        assertEquals(ModificationResult.ResponseEnum.REFUND_RECEIVED_, modificationResult.getResponse());
+        assertEquals(ModificationResult.ResponseEnum.REFUND_RECEIVED_.toString(), modificationResult.getResponse());
     }
 
     /**
@@ -120,7 +120,7 @@ public class ModificationTest extends BaseTest {
         CancelRequest cancelRequest = createBaseModificationRequest(new CancelRequest());
 
         ModificationResult modificationResult = modification.cancel(cancelRequest);
-        assertEquals(ModificationResult.ResponseEnum.CANCEL_RECEIVED_, modificationResult.getResponse());
+        assertEquals(ModificationResult.ResponseEnum.CANCEL_RECEIVED_.toString(), modificationResult.getResponse());
     }
 
     /**
@@ -136,7 +136,7 @@ public class ModificationTest extends BaseTest {
         VoidPendingRefundRequest voidPendingRefundRequest = createVoidPendingRefundRequest();
 
         ModificationResult modificationResult = modification.voidPendingRefund(voidPendingRefundRequest);
-        assertEquals(ModificationResult.ResponseEnum.VOIDPENDINGREFUND_RECEIVED_, modificationResult.getResponse());
+        assertEquals(ModificationResult.ResponseEnum.VOIDPENDINGREFUND_RECEIVED_.toString(), modificationResult.getResponse());
     }
 
     /**
@@ -152,6 +152,6 @@ public class ModificationTest extends BaseTest {
         DonationRequest donationRequest = createDonationRequest();
 
         ModificationResult modificationResult = modification.donate(donationRequest);
-        assertEquals(ModificationResult.ResponseEnum.DONATION_RECEIVED_, modificationResult.getResponse());
+        assertEquals(ModificationResult.ResponseEnum.DONATION_RECEIVED_.toString(), modificationResult.getResponse());
     }
 }


### PR DESCRIPTION
**Description**
some Modifications operations can result in synchronous responses, which are not included in the actual ResponseEnum.
Reason for this pull request is to allow all possible responses by changing the type of the variable to String.
This is a breaking change since the 'response' field type of these operations changed:
/adjustAuthorisation
/cancel
/cancelOrRefund
/capture
/donate
/refund
/technicalCancel
/voidPendingRefund

the ResponseEnum field is still there with a deprecated tag and message.

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
