### PR TITLE
fix: Android - java.security.KeyStoreException: JKS not found

### DIFF
--- a/src/main/java/com/adyen/httpclient/HttpURLConnectionClient.java
+++ b/src/main/java/com/adyen/httpclient/HttpURLConnectionClient.java
@@ -271,7 +271,7 @@ public class HttpURLConnectionClient implements ClientInterface {
                 CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
                 X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(certificateInput);
 
-                KeyStore keyStore = KeyStore.getInstance("JKS");
+                KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
                 keyStore.load(null, null);
                 keyStore.setCertificateEntry("TerminalCertificate", cert);
 


### PR DESCRIPTION
**Description**
JKS keystore is not available on Android. This fix uses the default keystore.

**Tested scenarios**
I have only tested on Android

**Fixed issue**:  #383 
