### PR TITLE
feat(config): terminal certificate stream

### DIFF
--- a/src/main/java/com/adyen/Config.java
+++ b/src/main/java/com/adyen/Config.java
@@ -20,6 +20,8 @@
  */
 package com.adyen;
 
+import java.io.InputStream;
+
 import com.adyen.enums.Environment;
 
 public class Config {
@@ -49,6 +51,7 @@ public class Config {
     protected String terminalApiCloudEndpoint;
     protected String terminalApiLocalEndpoint;
     protected String terminalCertificatePath;
+    protected InputStream terminalCertificateStream;
 
     public Config() {
         // do nothing
@@ -176,6 +179,14 @@ public class Config {
 
     public void setTerminalCertificatePath(String terminalCertificatePath) {
         this.terminalCertificatePath = terminalCertificatePath;
+    }
+
+    public InputStream getTerminalCertificateStream() {
+        return terminalCertificateStream;
+    }
+
+    public void setTerminalCertificateStream(InputStream terminalCertificateStream) {
+        this.terminalCertificateStream = terminalCertificateStream;
     }
 
     public int getConnectionTimeoutMillis() {

--- a/src/main/java/com/adyen/httpclient/HttpURLConnectionClient.java
+++ b/src/main/java/com/adyen/httpclient/HttpURLConnectionClient.java
@@ -86,9 +86,10 @@ public class HttpURLConnectionClient implements ClientInterface {
     public String request(String requestUrl, String requestBody, Config config, boolean isApiKeyRequired, RequestOptions requestOptions) throws IOException, HTTPClientException {
         HttpURLConnection httpConnection = createRequest(requestUrl, config.getApplicationName(), requestOptions);
 
-        if (config.getTerminalCertificatePath() != null && !config.getTerminalCertificatePath().isEmpty()) {
+        if ((config.getTerminalCertificatePath() != null && !config.getTerminalCertificatePath().isEmpty()) || (config.getTerminalCertificateStream() != null)) {
             Environment environment = getEnvironment(config);
-            installCertificateVerifier(httpConnection, config.getTerminalCertificatePath());
+            InputStream terminalCertificateStream = config.getTerminalCertificateStream() != null ? config.getTerminalCertificateStream() : this.loadCertificateInputStream(config.getTerminalCertificatePath());
+            installCertificateVerifier(httpConnection, terminalCertificateStream);
             installCertificateCommonNameValidator(httpConnection, environment);
         }
 
@@ -261,15 +262,15 @@ public class HttpURLConnectionClient implements ClientInterface {
         this.proxy = proxy;
     }
 
-    private void installCertificateVerifier(URLConnection connection, String terminalCertificatePath) throws HTTPClientException {
+    private void installCertificateVerifier(URLConnection connection, InputStream terminalCertificateStream) throws HTTPClientException {
         if (connection instanceof HttpsURLConnection) {
             HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
 
             try {
                 // Create new KeyStore for the terminal certificate
-                InputStream certificateInput = new FileInputStream(terminalCertificatePath);
                 CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
-                X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(certificateInput);
+                terminalCertificateStream.reset();
+                X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(terminalCertificateStream);
 
                 KeyStore keyStore = KeyStore.getInstance("JKS");
                 keyStore.load(null, null);
@@ -286,8 +287,17 @@ public class HttpURLConnectionClient implements ClientInterface {
                 sc.init(null, trustManagers, new java.security.SecureRandom());
                 httpsConnection.setSSLSocketFactory(sc.getSocketFactory());
             } catch (GeneralSecurityException | IOException e) {
-                throw new HTTPClientException("Error loading certificate from path", e);
+                throw new HTTPClientException("Error installing certificate verifier", e);
             }
+        }
+    }
+
+    private InputStream loadCertificateInputStream(String terminalCertificatePath) throws HTTPClientException {
+        try {
+            InputStream certificateInput = new FileInputStream(terminalCertificatePath);
+            return certificateInput;
+        } catch (IOException e) {
+            throw new HTTPClientException("Error loading certificate from path", e);
         }
     }
 


### PR DESCRIPTION
**Description**
Currently the only way to provide a terminal certificate to the library is via Config.terminalCertificatePath. On Android it makes more sense to store the certificates as resources as opposed to files in the file system.

**Tested scenarios**
Tested on Android only

**Fixed issue**:  #388 
