### PR TITLE
PW-2994 InputStream can only be reset if mark is supported

### DIFF
--- a/src/main/java/com/adyen/httpclient/HttpURLConnectionClient.java
+++ b/src/main/java/com/adyen/httpclient/HttpURLConnectionClient.java
@@ -269,7 +269,7 @@ public class HttpURLConnectionClient implements ClientInterface {
             try {
                 // Create new KeyStore for the terminal certificate
                 CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
-                terminalCertificateStream.reset();
+
                 X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(terminalCertificateStream);
 
                 KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());


### PR DESCRIPTION
**Description**
InputStream can only be reset if the given stream supports mark and it is set to correct position, otherwise it will throw IOException. Hence we have to assume that the stream is at the start of certificate data.

**Tested scenarios**

**Fixed issue**:  #402 
