### PR TITLE
Add metadata field to CreatePaymentLinkRequest

### DIFF
--- a/src/main/java/com/adyen/model/checkout/CreatePaymentLinkRequest.java
+++ b/src/main/java/com/adyen/model/checkout/CreatePaymentLinkRequest.java
@@ -26,8 +26,9 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.Objects;
-
 
 import static com.adyen.util.Util.toIndentedString;
 
@@ -79,6 +80,10 @@ public class CreatePaymentLinkRequest {
 
     @SerializedName("storePaymentMethod")
     private Boolean storePaymentMethod = null;
+
+    @SerializedName("metadata")
+    private Map<String, String> metadata = null;
+
 
     public CreatePaymentLinkRequest allowedPaymentMethods(List<String> allowedPaymentMethods) {
         this.allowedPaymentMethods = allowedPaymentMethods;
@@ -366,6 +371,33 @@ public class CreatePaymentLinkRequest {
         this.storePaymentMethod = storePaymentMethod;
     }
 
+    public CreatePaymentLinkRequest metadata(Map<String, String> metadata) {
+        this.metadata = metadata;
+        return this;
+    }
+
+    public CreatePaymentLinkRequest putMetadataItem(String key, String metadataItem) {
+
+        if (metadata == null) {
+            metadata = new HashMap<>();
+        }
+
+        metadata.put(key, metadataItem);
+        return this;
+    }
+
+    /**
+     * Metadata consists of entries, each of which includes a key and a value. Limitations: Error \&quot;177\&quot;, \&quot;Metadata size exceeds limit\&quot;
+     *
+     * @return metadata
+     **/
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -390,12 +422,13 @@ public class CreatePaymentLinkRequest {
                 Objects.equals(this.shopperEmail, createPaymentLinkRequest.shopperEmail) &&
                 Objects.equals(this.shopperLocale, createPaymentLinkRequest.shopperLocale) &&
                 Objects.equals(this.shopperReference, createPaymentLinkRequest.shopperReference) &&
-                Objects.equals(this.storePaymentMethod, createPaymentLinkRequest.storePaymentMethod);
+                Objects.equals(this.storePaymentMethod, createPaymentLinkRequest.storePaymentMethod) &&
+                Objects.equals(this.metadata, createPaymentLinkRequest.metadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(allowedPaymentMethods, amount, billingAddress, blockedPaymentMethods, countryCode, deliveryAddress, description, expiresAt, merchantAccount, reference, returnUrl, shopperEmail, shopperLocale, shopperReference, storePaymentMethod);
+        return Objects.hash(allowedPaymentMethods, amount, billingAddress, blockedPaymentMethods, countryCode, deliveryAddress, description, expiresAt, merchantAccount, reference, returnUrl, shopperEmail, shopperLocale, shopperReference, storePaymentMethod, metadata);
     }
 
 
@@ -419,6 +452,7 @@ public class CreatePaymentLinkRequest {
         sb.append("    shopperLocale: ").append(toIndentedString(shopperLocale)).append("\n");
         sb.append("    shopperReference: ").append(toIndentedString(shopperReference)).append("\n");
         sb.append("    storePaymentMethod: ").append(toIndentedString(storePaymentMethod)).append("\n");
+        sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
         sb.append("}");
         return sb.toString();
     }


### PR DESCRIPTION
**Description**
We make extensive use of the Java API Library in our stack. We have just started integrating _Pay By Link_ (https://docs.adyen.com/checkout/pay-by-link#create-payment-links-through-api) in our payment infrastructure. The current _9.0.0_ version lacks the ability to pass _metadata_ to the generated payment link. This PR adds this capability.

**Tested scenarios**
We have tested the integration manually by
- Compiling this PR and adding metadata to our `CreatePaymentLinkRequest`.
- Verifying the correct key/value pair for the associated payments in the `Customer Area` under the `Metadata`section.

I did not find a meaningful way to unit test this as neither [Create Payment Link](https://docs.adyen.com/api-explorer/#/CheckoutService/v64/post/paymentLinks) nor [Get Payment Link](https://docs.adyen.com/api-explorer/#/CheckoutService/v64/get/paymentLinks/{linkId}) return metadata at this point. I am happy to implement suggestions for a scenario that can be tested automatically.

**Fixed issue**:  <!-- #-prefixed issue number -->
- 