### PR TITLE
PW-3434 Added response constant for ModificationResult response field.

### DIFF
--- a/src/main/java/com/adyen/model/modification/ModificationResult.java
+++ b/src/main/java/com/adyen/model/modification/ModificationResult.java
@@ -36,6 +36,20 @@ import static com.adyen.util.Util.toIndentedString;
  */
 public class ModificationResult {
 
+    /**
+     * Response constants
+     */
+    public static class ModificationResponse {
+        public static final String CAPTURE_RECEIVED = "[capture-received]";
+        public static final String CANCEL_RECEIVED = "[cancel-received]";
+        public static final String TECHNICAL_CANCEL_RECEIVED = "[technical-cancel-received]";
+        public static final String REFUND_RECEIVED = "[refund-received]";
+        public static final String CANCELORREFUND_RECEIVED = "[cancelOrRefund-received]";
+        public static final String ADJUST_AUTHORISATION_RECEIVED = "[adjustAuthorisation-received]";
+        public static final String VOIDPENDINGREFUND_RECEIVED = "[voidPendingRefund-received]";
+        public static final String DONATION_RECEIVED = "[donation-received]";
+    }
+
     @SerializedName("pspReference")
     private String pspReference = null;
 

--- a/src/test/java/com/adyen/ModificationTest.java
+++ b/src/test/java/com/adyen/ModificationTest.java
@@ -47,7 +47,7 @@ public class ModificationTest extends BaseTest {
         CaptureRequest captureRequest = createCaptureRequest();
 
         ModificationResult modificationResult = modification.capture(captureRequest);
-        assertEquals("[capture-received]", modificationResult.getResponse());
+        assertEquals(ModificationResult.ModificationResponse.CAPTURE_RECEIVED, modificationResult.getResponse());
         assertEquals("test", modificationResult.getAdditionalData().get("merchantReference"));
     }
 
@@ -88,7 +88,7 @@ public class ModificationTest extends BaseTest {
         CancelOrRefundRequest cancelOrRefundRequest = createBaseModificationRequest(new CancelOrRefundRequest());
 
         ModificationResult modificationResult = modification.cancelOrRefund(cancelOrRefundRequest);
-        assertEquals("[cancelOrRefund-received]", modificationResult.getResponse());
+        assertEquals(ModificationResult.ModificationResponse.CANCELORREFUND_RECEIVED, modificationResult.getResponse());
     }
 
     /**
@@ -104,7 +104,7 @@ public class ModificationTest extends BaseTest {
         RefundRequest refundRequest = createRefundRequest();
 
         ModificationResult modificationResult = modification.refund(refundRequest);
-        assertEquals("[refund-received]", modificationResult.getResponse());
+        assertEquals(ModificationResult.ModificationResponse.REFUND_RECEIVED, modificationResult.getResponse());
     }
 
     /**
@@ -120,7 +120,7 @@ public class ModificationTest extends BaseTest {
         CancelRequest cancelRequest = createBaseModificationRequest(new CancelRequest());
 
         ModificationResult modificationResult = modification.cancel(cancelRequest);
-        assertEquals("[cancel-received]", modificationResult.getResponse());
+        assertEquals(ModificationResult.ModificationResponse.CANCEL_RECEIVED, modificationResult.getResponse());
     }
 
     /**
@@ -136,7 +136,7 @@ public class ModificationTest extends BaseTest {
         VoidPendingRefundRequest voidPendingRefundRequest = createVoidPendingRefundRequest();
 
         ModificationResult modificationResult = modification.voidPendingRefund(voidPendingRefundRequest);
-        assertEquals("[voidPendingRefund-received]", modificationResult.getResponse());
+        assertEquals(ModificationResult.ModificationResponse.VOIDPENDINGREFUND_RECEIVED, modificationResult.getResponse());
     }
 
     /**
@@ -152,6 +152,6 @@ public class ModificationTest extends BaseTest {
         DonationRequest donationRequest = createDonationRequest();
 
         ModificationResult modificationResult = modification.donate(donationRequest);
-        assertEquals("[donation-received]", modificationResult.getResponse());
+        assertEquals(ModificationResult.ModificationResponse.DONATION_RECEIVED, modificationResult.getResponse());
     }
 }


### PR DESCRIPTION
**Description**
Added constants for the field `response` in the `ModificationResult` class. 

**Tested scenarios**
All tests for `ModificationResult` model. 

**Fixed issue**:  
#458 
