### PR TITLE
PW-3870: Encrypt method change from ASCII to UTF_8

### DIFF
--- a/src/main/java/com/adyen/terminal/security/NexoCrypto.java
+++ b/src/main/java/com/adyen/terminal/security/NexoCrypto.java
@@ -51,7 +51,7 @@ public class NexoCrypto {
         validateSecurityKey(securityKey);
 
         NexoDerivedKey derivedKey = NexoDerivedKeyGenerator.deriveKeyMaterial(securityKey.getPassphrase());
-        byte[] saleToPoiMessageByteArray = saleToPoiMessageJson.getBytes(StandardCharsets.US_ASCII);
+        byte[] saleToPoiMessageByteArray = saleToPoiMessageJson.getBytes(StandardCharsets.UTF_8);
         byte[] ivNonce = generateRandomIvNonce();
         byte[] encryptedSaleToPoiMessage = crypt(saleToPoiMessageByteArray, derivedKey, ivNonce, Cipher.ENCRYPT_MODE);
         byte[] encryptedSaleToPoiMessageHmac = hmac(saleToPoiMessageByteArray, derivedKey);


### PR DESCRIPTION
**Description**
All terminals are working in UTF_8, might be a breaking change, will release major version.

**Tested scenarios**
Local terminal test display QR code with text and UTF_8 characters
