### PR TITLE
Overload addEncryptedCardData method to use without holdername

### DIFF
--- a/src/main/java/com/adyen/model/checkout/PaymentsRequest.java
+++ b/src/main/java/com/adyen/model/checkout/PaymentsRequest.java
@@ -745,6 +745,10 @@ public class PaymentsRequest {
         return this;
     }
 
+    public PaymentsRequest addEncryptedCardData(String encryptedCardNumber, String encryptedExpiryMonth, String encryptedExpiryYear, String encryptedSecurityCode) {
+        return addEncryptedCardData(encryptedCardNumber, encryptedExpiryMonth, encryptedExpiryYear, encryptedSecurityCode, null, null);
+    }
+
     public PaymentsRequest addEncryptedCardData(String encryptedCardNumber, String encryptedExpiryMonth, String encryptedExpiryYear, String encryptedSecurityCode, String holderName) {
         return addEncryptedCardData(encryptedCardNumber, encryptedExpiryMonth, encryptedExpiryYear, encryptedSecurityCode, holderName, null);
     }

--- a/src/test/java/com/adyen/CheckoutTest.java
+++ b/src/test/java/com/adyen/CheckoutTest.java
@@ -181,6 +181,19 @@ public class CheckoutTest extends BaseTest {
     }
 
     /**
+     * Test success flow for
+     * POST /payments
+     */
+    @Test
+    public void TestEncryptedPaymentsWithoutHoldernameSuccessMocked() throws Exception {
+        Client client = createMockClientFromFile("mocks/checkout/payments-encrypted-without-holdername-success.json");
+        Checkout checkout = new Checkout(client);
+        PaymentsRequest paymentsRequest = createEncryptedPaymentsCheckoutRequestWithoutHoldername();
+        PaymentsResponse paymentsResponse = checkout.payments(paymentsRequest);
+        assertEquals("853613724697009G", paymentsResponse.getPspReference());
+    }
+
+    /**
      * Test error flow for
      * POST /payments
      */
@@ -1981,6 +1994,19 @@ public class CheckoutTest extends BaseTest {
         paymentsRequest.setReference("Your order number");
         paymentsRequest.setAmount(createAmountObject("USD", 1000L));
         paymentsRequest.addEncryptedCardData("test_4111111111111111", "test_03", "test_2030", "test_737", "John Smith");
+
+        paymentsRequest.setReturnUrl("https://your-company.com/...");
+        paymentsRequest.setMerchantAccount("MagentoMerchantTest");
+
+        return paymentsRequest;
+    }
+
+    protected PaymentsRequest createEncryptedPaymentsCheckoutRequestWithoutHoldername() {
+        PaymentsRequest paymentsRequest = new PaymentsRequest();
+
+        paymentsRequest.setReference("Your order number");
+        paymentsRequest.setAmount(createAmountObject("USD", 1000L));
+        paymentsRequest.addEncryptedCardData("test_4111111111111111", "test_03", "test_2030", "test_737");
 
         paymentsRequest.setReturnUrl("https://your-company.com/...");
         paymentsRequest.setMerchantAccount("MagentoMerchantTest");

--- a/src/test/resources/mocks/checkout/payments-encrypted-without-holdername-success.json
+++ b/src/test/resources/mocks/checkout/payments-encrypted-without-holdername-success.json
@@ -1,0 +1,69 @@
+{
+  "additionalData": {
+    "expiryDate": "3/2030",
+    "fraudResultType": "GREEN",
+    "cardBin": "411111",
+    "cardHolderName": "Checkout Shopper PlaceHolder",
+    "cardSummary": "1111",
+    "fraudManualReview": "false",
+    "aliasType": "Default",
+    "alias": "H167852639363479",
+    "paymentMethod": "visa",
+    "paymentMethodVariant": "visa",
+    "merchantReference": "Your order number"
+  },
+  "fraudResult": {
+    "accountScore": 0,
+    "results": [
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 2,
+          "name": "CardChunkUsage"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 3,
+          "name": "PaymentDetailUsage"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 1,
+          "name": "PaymentDetailRefCheck"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 13,
+          "name": "IssuerRefCheck"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 15,
+          "name": "IssuingCountryReferral"
+        }
+      },
+      {
+        "FraudCheckResult": {
+          "accountScore": 0,
+          "checkId": 25,
+          "name": "CVCAuthResultCheck"
+        }
+      }
+    ]
+  },
+  "pspReference": "853613724697009G",
+  "resultCode": "Authorised",
+  "amount": {
+    "currency": "USD",
+    "value": 1000
+  },
+  "merchantReference": "Your order number"
+}


### PR DESCRIPTION
**Description**
Overload _addEncryptedCardData_ so it can be used without _holdername_.