### PR TITLE
Change AccountCreated notification content

### DIFF
--- a/src/main/java/com/adyen/model/marketpay/notification/AccountCreatedNotification.java
+++ b/src/main/java/com/adyen/model/marketpay/notification/AccountCreatedNotification.java
@@ -21,18 +21,18 @@
 
 package com.adyen.model.marketpay.notification;
 
-import com.adyen.model.marketpay.CreateAccountHolderResponse;
+import com.adyen.model.marketpay.CreateAccountResponse;
 import com.google.gson.annotations.SerializedName;
 
 public class AccountCreatedNotification extends GenericNotification {
     @SerializedName("content")
-    private CreateAccountHolderResponse content;
+    private CreateAccountResponse content;
 
-    public CreateAccountHolderResponse getContent() {
+    public CreateAccountResponse getContent() {
         return content;
     }
 
-    public void setContent(CreateAccountHolderResponse content) {
+    public void setContent(CreateAccountResponse content) {
         this.content = content;
     }
 

--- a/src/test/resources/mocks/marketpay/notification/account-created-success.json
+++ b/src/test/resources/mocks/marketpay/notification/account-created-success.json
@@ -1,11 +1,37 @@
 {
+  "error": {
+    "errorCode": "000",
+    "message": "test error message"
+  },
+  "eventDate": "2019-01-01T01:00:00+01:00",
   "eventType": "ACCOUNT_CREATED",
   "executingUserKey": "ws",
   "live": "true",
   "pspReference": "Test_ACCOUNT_CREATED",
   "content": {
+    "invalidFields": [
+      {
+        "errorCode": 1,
+        "errorDescription": "Field is missing",
+        "fieldType": {
+          "field": "AccountHolderDetails.BusinessDetails.Shareholders.unknown",
+          "fieldName": "unknown",
+          "shareholderCode": "SH00001"
+        }
+      }
+    ],
     "pspReference": "Test_ACCOUNT_CREATED",
+    "resultCode": "Success",
+    "accountCode": "AC0000000001",
     "accountHolderCode": "TestAccountHolder",
+    "description": "account description",
+    "metadata": {
+      "MetaKey": "MetaValue"
+    },
+    "payoutSchedule": {
+      "nextScheduledPayout": "1970-01-02T01:00:00+01:00",
+      "schedule": "DAILY"
+    },
     "status": "Active"
   }
 }


### PR DESCRIPTION
The notification AccountCreatedNotification contains the wrong content type (CreateAccountHolderResponse instead of CreateAccountResponse) and therefore some fields from the notification are not available. 
