### PR TITLE
Changed matcher.group() parameter to prevent UnsupportedOperationException on some older Android devices.

### DIFF
--- a/src/main/java/com/adyen/terminal/security/TerminalCommonNameValidator.java
+++ b/src/main/java/com/adyen/terminal/security/TerminalCommonNameValidator.java
@@ -44,9 +44,9 @@ public final class TerminalCommonNameValidator {
         Matcher matcher = pattern.matcher(name);
         boolean valid = false;
         while (matcher.find() && !valid) {
-            String groupName = matcher.group("name");
+            String groupName = matcher.group(1);
             if ("CN".equals(groupName)) {
-                String commonName = matcher.group("val");
+                String commonName = matcher.group(2);
                 valid = commonName.matches(TERMINAL_API_CN_REGEX.replace(ENVIRONMENT_WILDCARD, environmentName))
                         || commonName.equals(TERMINAL_API_LEGACY_CN.replace(ENVIRONMENT_WILDCARD, environmentName));
             }


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Using the matcher.group() function with the parameter of int instead of String. Stops an 'UnsupportedOperationException' being thrown when used on some Android devices.

 - group(1) returns the common name
 - group(2) returns the value

It seems like the internals of the matcher.group(String) function works out the index before executing the same code as the matcher.group(index). 

Also, checked to make sure that matcher.group(int) was not deprecated before using it, still a supported and used method.

**Tested scenarios**
<!-- Description of tested scenarios -->

- Tested changes on Android devices with the OS ranging from 7-10
- Executed the existing test scripts in the TerminalCommonNameValidatorTest class 

**Fixed issue**:  <!-- #-prefixed issue number -->
