### PR TITLE
fix sdkInterfaceEnum for the values html and native. Fixes #510

### DIFF
--- a/src/main/java/com/adyen/model/DeviceRenderOptions.java
+++ b/src/main/java/com/adyen/model/DeviceRenderOptions.java
@@ -49,8 +49,8 @@ public class DeviceRenderOptions {
     @JsonAdapter(SdkInterfaceEnum.Adapter.class)
     public enum SdkInterfaceEnum {
 
-        HTML("Html"),
-        NATIVE("Native"),
+        HTML("html"),
+        NATIVE("native"),
         BOTH("both");
 
         @JsonValue


### PR DESCRIPTION
**Description**
According to specs: https://docs.adyen.com/api-explorer/#/CheckoutService/v67/post/payments__reqParam_threeDS2RequestData-deviceRenderOptions-sdkInterface the the first letter of the values of `sdkInterface` is lowercase.

**Fixed issue**:  #510 