### PR TITLE
Added missing enum values to KYCCheckStatusData, updated tests

### DIFF
--- a/src/main/java/com/adyen/model/marketpay/KYCCheckStatusData.java
+++ b/src/main/java/com/adyen/model/marketpay/KYCCheckStatusData.java
@@ -14,164 +14,153 @@
  *
  * Adyen Java API Library
  *
- * Copyright (c) 2017 Adyen B.V.
+ * Copyright (c) 2021 Adyen B.V.
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  */
+
 package com.adyen.model.marketpay;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
 
 import static com.adyen.util.Util.toIndentedString;
 
 /**
  * KYCCheckStatusData
  */
+
 public class KYCCheckStatusData {
+    @SerializedName("requiredFields")
+    private List<String> requiredFields = null;
+
     /**
-     * check type
+     * The status of the check. &gt;Permitted Values: &#x60;DATA_PROVIDED&#x60;, &#x60;PASSED&#x60;, &#x60;PENDING&#x60;, &#x60;AWAITING_DATA&#x60;, &#x60;RETRY_LIMIT_REACHED&#x60;, &#x60;INVALID_DATA&#x60;, &#x60;FAILED&#x60;.
      */
-    public enum CheckTypeEnum {
-        @SerializedName("BANK_ACCOUNT_VERIFICATION")
-        BANK_ACCOUNT_VERIFICATION("BANK_ACCOUNT_VERIFICATION"),
-
-        @SerializedName("COMPANY_VERIFICATION")
-        COMPANY_VERIFICATION("COMPANY_VERIFICATION"),
-
-        @SerializedName("IDENTITY_VERIFICATION")
-        IDENTITY_VERIFICATION("IDENTITY_VERIFICATION"),
-
-        @SerializedName("PASSPORT_VERIFICATION")
-        PASSPORT_VERIFICATION("PASSPORT_VERIFICATION");
+    @JsonAdapter(StatusEnum.Adapter.class)
+    public enum StatusEnum {
+        AWAITING_DATA("AWAITING_DATA"),
+        DATA_PROVIDED("DATA_PROVIDED"),
+        FAILED("FAILED"),
+        INVALID_DATA("INVALID_DATA"),
+        PASSED("PASSED"),
+        PENDING("PENDING"),
+        PENDING_REVIEW("PENDING_REVIEW"),
+        RETRY_LIMIT_REACHED("RETRY_LIMIT_REACHED"),
+        UNCHECKED("UNCHECKED");
 
         private String value;
 
-        CheckTypeEnum(String value) {
+        StatusEnum(String value) {
             this.value = value;
+        }
+
+        public String getValue() {
+            return value;
         }
 
         @Override
         public String toString() {
             return String.valueOf(value);
         }
+
+        public static StatusEnum fromValue(String text) {
+            for (StatusEnum b : StatusEnum.values()) {
+                if (String.valueOf(b.value).equals(text)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static class Adapter extends TypeAdapter<StatusEnum> {
+            @Override
+            public void write(final JsonWriter jsonWriter, final StatusEnum enumeration) throws IOException {
+                jsonWriter.value(enumeration.getValue());
+            }
+
+            @Override
+            public StatusEnum read(final JsonReader jsonReader) throws IOException {
+                Object value = jsonReader.nextString();
+                return StatusEnum.fromValue(String.valueOf(value));
+            }
+        }
     }
 
-    @SerializedName("type")
-    @JsonProperty("type")
-    private CheckTypeEnum checkType = null;
+    @SerializedName("status")
+    private StatusEnum status = null;
 
     @SerializedName("summary")
     private KYCCheckSummary summary = null;
 
     /**
-     * check status
+     * The type of check. &gt;Permitted Values: &#x60;COMPANY_VERIFICATION&#x60;, &#x60;IDENTITY_VERIFICATION&#x60;, &#x60;PASSPORT_VERIFICATION&#x60;, &#x60;BANK_ACCOUNT_VERIFICATION&#x60;, &#x60;NONPROFIT_VERIFICATION&#x60;, &#x60;CARD_VERIFICATION&#x60;.
      */
-    public enum CheckStatusEnum {
-        @SerializedName("AWAITING_DATA")
-        AWAITING_DATA("AWAITING_DATA"),
-
-        @SerializedName("DATA_PROVIDED")
-        DATA_PROVIDED("DATA_PROVIDED"),
-
-        @SerializedName("FAILED")
-        FAILED("FAILED"),
-
-        @SerializedName("INVALID_DATA")
-        INVALID_DATA("INVALID_DATA"),
-
-        @SerializedName("PASSED")
-        PASSED("PASSED"),
-
-        @SerializedName("PENDING")
-        PENDING("PENDING"),
-
-        @SerializedName("PENDING_REVIEW")
-        PENDING_REVIEW("PENDING_REVIEW"),
-
-        @SerializedName("RETRY_LIMIT_REACHED")
-        RETRY_LIMIT_REACHED("RETRY_LIMIT_REACHED"),
-
-        @SerializedName("UNCHECKED")
-        UNCHECKED("UNCHECKED");
+    @JsonAdapter(TypeEnum.Adapter.class)
+    public enum TypeEnum {
+        BANK_ACCOUNT_VERIFICATION("BANK_ACCOUNT_VERIFICATION"),
+        CARD_VERIFICATION("CARD_VERIFICATION"),
+        COMPANY_VERIFICATION("COMPANY_VERIFICATION"),
+        CRIMINAL_BACKGROUND_EXTENSIVE_VERIFICATION("CRIMINAL_BACKGROUND_EXTENSIVE_VERIFICATION"),
+        CRIMINAL_BACKGROUND_MEDIUM_VERIFICATION("CRIMINAL_BACKGROUND_MEDIUM_VERIFICATION"),
+        IDENTITY_VERIFICATION("IDENTITY_VERIFICATION"),
+        LEGAL_ARRANGEMENT_VERIFICATION("LEGAL_ARRANGEMENT_VERIFICATION"),
+        NONPROFIT_VERIFICATION("NONPROFIT_VERIFICATION"),
+        PASSPORT_VERIFICATION("PASSPORT_VERIFICATION"),
+        PAYOUT_METHOD_VERIFICATION("PAYOUT_METHOD_VERIFICATION"),
+        PCI_SELF_ASSESSMENT_PRESENCE_VERIFICATION("PCI_SELF_ASSESSMENT_PRESENCE_VERIFICATION"),
+        PCI_VERIFICATION("PCI_VERIFICATION"),
+        POLITICALLY_EXPOSED_IDENTIFICATION_VERIFICATION("POLITICALLY_EXPOSED_IDENTIFICATION_VERIFICATION"),
+        POLITICALLY_EXPOSED_VERIFICATION("POLITICALLY_EXPOSED_VERIFICATION");
 
         private String value;
 
-        CheckStatusEnum(String value) {
+        TypeEnum(String value) {
             this.value = value;
+        }
+
+        public String getValue() {
+            return value;
         }
 
         @Override
         public String toString() {
             return String.valueOf(value);
         }
+
+        public static TypeEnum fromValue(String text) {
+            for (TypeEnum b : TypeEnum.values()) {
+                if (String.valueOf(b.value).equals(text)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static class Adapter extends TypeAdapter<TypeEnum> {
+            @Override
+            public void write(final JsonWriter jsonWriter, final TypeEnum enumeration) throws IOException {
+                jsonWriter.value(enumeration.getValue());
+            }
+
+            @Override
+            public TypeEnum read(final JsonReader jsonReader) throws IOException {
+                Object value = jsonReader.nextString();
+                return TypeEnum.fromValue(String.valueOf(value));
+            }
+        }
     }
 
-    @SerializedName("status")
-    @JsonProperty("status")
-    private CheckStatusEnum checkStatus = null;
-
-    @SerializedName("requiredFields")
-    private List<String> requiredFields = new ArrayList<>();
-
-    public KYCCheckStatusData checkType(CheckTypeEnum checkType) {
-        this.checkType = checkType;
-        return this;
-    }
-
-    /**
-     * check type
-     *
-     * @return checkType
-     **/
-    public CheckTypeEnum getCheckType() {
-        return checkType;
-    }
-
-    public void setCheckType(CheckTypeEnum checkType) {
-        this.checkType = checkType;
-    }
-
-    public KYCCheckStatusData summary(KYCCheckSummary summary) {
-        this.summary = summary;
-        return this;
-    }
-
-    /**
-     * check execution summary
-     *
-     * @return summary
-     **/
-    public KYCCheckSummary getSummary() {
-        return summary;
-    }
-
-    public void setSummary(KYCCheckSummary summary) {
-        this.summary = summary;
-    }
-
-    public KYCCheckStatusData checkStatus(CheckStatusEnum checkStatus) {
-        this.checkStatus = checkStatus;
-        return this;
-    }
-
-    /**
-     * check status
-     *
-     * @return checkStatus
-     **/
-    public CheckStatusEnum getCheckStatus() {
-        return checkStatus;
-    }
-
-    public void setCheckStatus(CheckStatusEnum checkStatus) {
-        this.checkStatus = checkStatus;
-    }
+    @SerializedName("type")
+    private TypeEnum type = null;
 
     public KYCCheckStatusData requiredFields(List<String> requiredFields) {
         this.requiredFields = requiredFields;
@@ -179,12 +168,15 @@ public class KYCCheckStatusData {
     }
 
     public KYCCheckStatusData addRequiredFieldsItem(String requiredFieldsItem) {
+        if (this.requiredFields == null) {
+            this.requiredFields = new ArrayList<String>();
+        }
         this.requiredFields.add(requiredFieldsItem);
         return this;
     }
 
     /**
-     * required fields
+     * A list of the fields required for execution of the check.
      *
      * @return requiredFields
      **/
@@ -196,9 +188,63 @@ public class KYCCheckStatusData {
         this.requiredFields = requiredFields;
     }
 
+    public KYCCheckStatusData status(StatusEnum status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * The status of the check. &gt;Permitted Values: &#x60;DATA_PROVIDED&#x60;, &#x60;PASSED&#x60;, &#x60;PENDING&#x60;, &#x60;AWAITING_DATA&#x60;, &#x60;RETRY_LIMIT_REACHED&#x60;, &#x60;INVALID_DATA&#x60;, &#x60;FAILED&#x60;.
+     *
+     * @return status
+     **/
+    public StatusEnum getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    public KYCCheckStatusData summary(KYCCheckSummary summary) {
+        this.summary = summary;
+        return this;
+    }
+
+    /**
+     * Get summary
+     *
+     * @return summary
+     **/
+    public KYCCheckSummary getSummary() {
+        return summary;
+    }
+
+    public void setSummary(KYCCheckSummary summary) {
+        this.summary = summary;
+    }
+
+    public KYCCheckStatusData type(TypeEnum type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * The type of check. &gt;Permitted Values: &#x60;COMPANY_VERIFICATION&#x60;, &#x60;IDENTITY_VERIFICATION&#x60;, &#x60;PASSPORT_VERIFICATION&#x60;, &#x60;BANK_ACCOUNT_VERIFICATION&#x60;, &#x60;NONPROFIT_VERIFICATION&#x60;, &#x60;CARD_VERIFICATION&#x60;.
+     *
+     * @return type
+     **/
+    public TypeEnum getType() {
+        return type;
+    }
+
+    public void setType(TypeEnum type) {
+        this.type = type;
+    }
+
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(java.lang.Object o) {
         if (this == o) {
             return true;
         }
@@ -206,16 +252,15 @@ public class KYCCheckStatusData {
             return false;
         }
         KYCCheckStatusData kyCCheckStatusData = (KYCCheckStatusData) o;
-        return Objects.equals(this.checkType, kyCCheckStatusData.checkType)
-                && Objects.equals(this.summary, kyCCheckStatusData.summary)
-                && Objects.equals(this.checkStatus,
-                                  kyCCheckStatusData.checkStatus)
-                && Objects.equals(this.requiredFields, kyCCheckStatusData.requiredFields);
+        return Objects.equals(this.requiredFields, kyCCheckStatusData.requiredFields) &&
+                Objects.equals(this.status, kyCCheckStatusData.status) &&
+                Objects.equals(this.summary, kyCCheckStatusData.summary) &&
+                Objects.equals(this.type, kyCCheckStatusData.type);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(checkType, summary, checkStatus, requiredFields);
+        return Objects.hash(requiredFields, status, summary, type);
     }
 
 
@@ -224,15 +269,13 @@ public class KYCCheckStatusData {
         StringBuilder sb = new StringBuilder();
         sb.append("class KYCCheckStatusData {\n");
 
-        sb.append("    checkType: ").append(toIndentedString(checkType)).append("\n");
-        sb.append("    summary: ").append(toIndentedString(summary)).append("\n");
-        sb.append("    checkStatus: ").append(toIndentedString(checkStatus)).append("\n");
         sb.append("    requiredFields: ").append(toIndentedString(requiredFields)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    summary: ").append(toIndentedString(summary)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("}");
         return sb.toString();
     }
 
 
-
 }
-

--- a/src/test/java/com/adyen/MarketPayNotificationTest.java
+++ b/src/test/java/com/adyen/MarketPayNotificationTest.java
@@ -31,9 +31,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static com.adyen.model.marketpay.CreateAccountResponse.StatusEnum.ACTIVE;
-import static com.adyen.model.marketpay.KYCCheckStatusData.CheckStatusEnum.DATA_PROVIDED;
-import static com.adyen.model.marketpay.KYCCheckStatusData.CheckTypeEnum.COMPANY_VERIFICATION;
-import static com.adyen.model.marketpay.KYCCheckStatusData.CheckTypeEnum.IDENTITY_VERIFICATION;
+import static com.adyen.model.marketpay.KYCCheckStatusData.StatusEnum.DATA_PROVIDED;
+import static com.adyen.model.marketpay.KYCCheckStatusData.TypeEnum.COMPANY_VERIFICATION;
 import static com.adyen.model.marketpay.PayoutScheduleResponse.ScheduleEnum.DAILY;
 import static com.adyen.model.marketpay.Transaction.TransactionStatusEnum.PENDINGCREDIT;
 import static com.adyen.model.marketpay.notification.NotificationEventConfiguration.EventTypeEnum.ACCOUNT_HOLDER_STATUS_CHANGE;
@@ -236,9 +235,9 @@ public class MarketPayNotificationTest extends BaseTest {
 
         assertEquals("accountHolderCode", notification.getContent().getAccountHolderCode());
         assertEquals(AccountHolderStatus.StatusEnum.ACTIVE, notification.getContent().getAccountHolderStatus().getStatus());
-        assertEquals(COMPANY_VERIFICATION, notification.getContent().getVerificationResult().getAccountHolder().getChecks().get(0).getCheckType());
-        assertEquals(DATA_PROVIDED, notification.getContent().getVerificationResult().getAccountHolder().getChecks().get(0).getCheckStatus());
-        assertEquals(DATA_PROVIDED, notification.getContent().getVerificationResult().getShareholders().get(0).getChecks().get(0).getCheckStatus());
+        assertEquals(COMPANY_VERIFICATION, notification.getContent().getVerificationResult().getAccountHolder().getChecks().get(0).getType());
+        assertEquals(DATA_PROVIDED, notification.getContent().getVerificationResult().getAccountHolder().getChecks().get(0).getStatus());
+        assertEquals(DATA_PROVIDED, notification.getContent().getVerificationResult().getShareholders().get(0).getChecks().get(0).getStatus());
     }
 
     @Test

--- a/src/test/java/com/adyen/MarketPayTest.java
+++ b/src/test/java/com/adyen/MarketPayTest.java
@@ -46,11 +46,11 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import static com.adyen.model.marketpay.AccountEvent.EventEnum.INACTIVATEACCOUNT;
-import static com.adyen.model.marketpay.KYCCheckStatusData.CheckStatusEnum.AWAITING_DATA;
-import static com.adyen.model.marketpay.KYCCheckStatusData.CheckStatusEnum.PASSED;
-import static com.adyen.model.marketpay.KYCCheckStatusData.CheckTypeEnum.BANK_ACCOUNT_VERIFICATION;
-import static com.adyen.model.marketpay.KYCCheckStatusData.CheckTypeEnum.COMPANY_VERIFICATION;
-import static com.adyen.model.marketpay.KYCCheckStatusData.CheckTypeEnum.IDENTITY_VERIFICATION;
+import static com.adyen.model.marketpay.KYCCheckStatusData.StatusEnum.AWAITING_DATA;
+import static com.adyen.model.marketpay.KYCCheckStatusData.StatusEnum.PASSED;
+import static com.adyen.model.marketpay.KYCCheckStatusData.TypeEnum.BANK_ACCOUNT_VERIFICATION;
+import static com.adyen.model.marketpay.KYCCheckStatusData.TypeEnum.COMPANY_VERIFICATION;
+import static com.adyen.model.marketpay.KYCCheckStatusData.TypeEnum.IDENTITY_VERIFICATION;
 import static org.junit.Assert.*;
 
 /**
@@ -219,8 +219,8 @@ public class MarketPayTest extends BaseTest {
 
         assertEquals("140922935", createAccountHolderResponse.getAccountCode());
         assertEquals("681d5df6-cf38-4557-aecd-ac8ed0c04195", createAccountHolderResponse.getAccountHolderDetails().getBankAccountDetails().get(0).getBankAccountUUID());
-        assertEquals(BANK_ACCOUNT_VERIFICATION, createAccountHolderResponse.getVerification().getBankAccounts().get(0).getChecks().get(0).getCheckType());
-        assertEquals(PASSED, createAccountHolderResponse.getVerification().getBankAccounts().get(0).getChecks().get(0).getCheckStatus());
+        assertEquals(BANK_ACCOUNT_VERIFICATION, createAccountHolderResponse.getVerification().getBankAccounts().get(0).getChecks().get(0).getType());
+        assertEquals(PASSED, createAccountHolderResponse.getVerification().getBankAccounts().get(0).getChecks().get(0).getStatus());
         assertEquals("705c2619-a9fb-48da-a121-c83fc37ee1cf", createAccountHolderResponse.getVerificationProfile());
     }
 
@@ -327,8 +327,8 @@ public class MarketPayTest extends BaseTest {
 
         assertEquals("6026a526-7863-aaaa-dddd-f8fadc47473e", getAccountHolderResponse.getAccountHolderDetails().getBankAccountDetails().get(0).getBankAccountUUID());
         assertEquals("115548513", getAccountHolderResponse.getAccounts().get(0).getAccountCode());
-        assertEquals(IDENTITY_VERIFICATION, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getCheckType());
-        assertEquals(AWAITING_DATA, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getCheckStatus());
+        assertEquals(IDENTITY_VERIFICATION, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getType());
+        assertEquals(AWAITING_DATA, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getStatus());
         assertNotNull(getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getRequiredFields());
         assertEquals("AccountHolderDetails.Address.address", getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getRequiredFields().get(0));
         assertEquals("AccountHolderDetails.PhoneNumber.phoneNumber", getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getRequiredFields().get(1));
@@ -360,8 +360,8 @@ public class MarketPayTest extends BaseTest {
         assertEquals("1abf8304-58c7-4a9e-8bd3-4d7eff9801e4", getAccountHolderResponse.getAccountHolderDetails().getBankAccountDetails().get(0).getBankAccountUUID());
         assertEquals("67890", getAccountHolderResponse.getAccountHolderDetails().getBusinessDetails().getShareholders().get(0).getAddress().getPostalCode());
         assertEquals("115548513", getAccountHolderResponse.getAccounts().get(0).getAccountCode());
-        assertEquals(COMPANY_VERIFICATION, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getCheckType());
-        assertEquals(PASSED, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getCheckStatus());
+        assertEquals(COMPANY_VERIFICATION, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getType());
+        assertEquals(PASSED, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getStatus());
         assertEquals(1602, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getSummary().getKycCheckCode().intValue());
         assertEquals("Passed", getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getSummary().getKycCheckDescription());
         assertEquals("FBAR", getAccountHolderResponse.getAccountHolderDetails().getBusinessDetails().getStockExchange());


### PR DESCRIPTION
**Description**
added missing enum values to KYCCheckStatusData.
getters/setters for these fields in KYCCheckStatusData changed:
`checkStatus` -> `status`
`checkType` -> `type`
major version bump is needed.