### PR TITLE
Parsing ACCOUNT_HOLDER_PAYOUT notification throws exception

### DIFF
--- a/src/main/java/com/adyen/model/marketpay/notification/AccountHolderPayoutNotificationContent.java
+++ b/src/main/java/com/adyen/model/marketpay/notification/AccountHolderPayoutNotificationContent.java
@@ -21,11 +21,6 @@
 
 package com.adyen.model.marketpay.notification;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 import com.adyen.model.Amount;
 import com.adyen.model.marketpay.BankAccountDetail;
 import com.google.gson.TypeAdapter;
@@ -35,6 +30,10 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
 
 import static com.adyen.util.Util.toIndentedString;
 
@@ -59,7 +58,7 @@ public class AccountHolderPayoutNotificationContent {
     private String description = null;
 
     @SerializedName("estimatedArrivalDate")
-    private LocalDate estimatedArrivalDate = null;
+    private Date estimatedArrivalDate = null;
 
     @SerializedName("invalidFields")
     private List<ErrorFieldType> invalidFields = null;
@@ -236,7 +235,7 @@ public class AccountHolderPayoutNotificationContent {
         this.description = description;
     }
 
-    public AccountHolderPayoutNotificationContent estimatedArrivalDate(LocalDate estimatedArrivalDate) {
+    public AccountHolderPayoutNotificationContent estimatedArrivalDate(Date estimatedArrivalDate) {
         this.estimatedArrivalDate = estimatedArrivalDate;
         return this;
     }
@@ -246,11 +245,11 @@ public class AccountHolderPayoutNotificationContent {
      *
      * @return estimatedArrivalDate
      **/
-    public LocalDate getEstimatedArrivalDate() {
+    public Date getEstimatedArrivalDate() {
         return estimatedArrivalDate;
     }
 
-    public void setEstimatedArrivalDate(LocalDate estimatedArrivalDate) {
+    public void setEstimatedArrivalDate(Date estimatedArrivalDate) {
         this.estimatedArrivalDate = estimatedArrivalDate;
     }
 

--- a/src/test/java/com/adyen/MarketPayNotificationTest.java
+++ b/src/test/java/com/adyen/MarketPayNotificationTest.java
@@ -222,6 +222,22 @@ public class MarketPayNotificationTest extends BaseTest {
     }
 
     @Test
+    public void testMarketPayAccountHolderPayoutNotification() {
+        String json = getFileContents("mocks/marketpay/notification/account-holder-payout.json");
+        NotificationHandler notificationHandler = new NotificationHandler();
+
+        GenericNotification notificationMessage = notificationHandler.handleMarketpayNotificationJson(json);
+
+        assertEquals(GenericNotification.EventTypeEnum.ACCOUNT_HOLDER_PAYOUT, notificationMessage.getEventType());
+        AccountHolderPayoutNotification notification = (AccountHolderPayoutNotification) notificationMessage;
+        assertNotNull(notification.getContent());
+
+        assertEquals("AC00000001", notification.getContent().getAccountCode());
+        assertEquals(1, notification.getContent().getAmounts().size());
+        assertEquals(1500L, notification.getContent().getAmounts().get(0).getValue().longValue());
+    }
+
+    @Test
     public void testMarketPayAccountHolderUpdatedNotification() {
         String json = getFileContents("mocks/marketpay/notification/account-holder-updated.json");
         NotificationHandler notificationHandler = new NotificationHandler();

--- a/src/test/resources/mocks/marketpay/notification/account-holder-payout.json
+++ b/src/test/resources/mocks/marketpay/notification/account-holder-payout.json
@@ -1,0 +1,32 @@
+{
+  "eventDate": "2021-05-06T16:00:11+02:00",
+  "eventType": "ACCOUNT_HOLDER_PAYOUT",
+  "executingUserKey": "Payout",
+  "live": false,
+  "pspReference": "8816255596048747",
+  "content": {
+    "accountCode": "AC00000001",
+    "accountHolderCode": "AH00000001",
+    "amounts": [
+      {
+        "currency": "EUR",
+        "value": 1500
+      }
+    ],
+    "bankAccountDetail": {
+      "bankAccountUUID": "778e4fff-6ea4-4584-9e1d-af5a5f6bb187",
+      "countryCode": "AT",
+      "currencyCode": "EUR",
+      "iban": "AT883400071439643338",
+      "ownerDateOfBirth": "1990-07-25",
+      "ownerName": "Tester Name",
+      "primaryAccount": false
+    },
+    "description": "description of payout",
+    "estimatedArrivalDate": "2021-05-07",
+    "payoutSpeed": "STANDARD",
+    "status": {
+      "statusCode": "Initiated"
+    }
+  }
+}


### PR DESCRIPTION
Changing the type of the estimatedArrivalDate field on the AccountHolderPayoutNotificationContent from LocalDate to Date because parsing to LocalDate did lead to an exception.


**Fixed issue**:  #539 
