### PR TITLE
Remove named groups from the regex

### DIFF
--- a/src/main/java/com/adyen/terminal/security/TerminalCommonNameValidator.java
+++ b/src/main/java/com/adyen/terminal/security/TerminalCommonNameValidator.java
@@ -39,7 +39,7 @@ public final class TerminalCommonNameValidator {
     public static boolean validateCertificate(X509Certificate certificate, Environment environment) {
         String environmentName = environment.name().toLowerCase();
         String name = certificate.getSubjectDN().getName();
-        String patternRegex = "(?:^|,\\s?)(?:(?<name>[A-Z]+)=(?<val>\"(?:[^\"]|\"\")+\"|[^,]+))+";
+        String patternRegex = "(?:^|,\\s?)(?:([A-Z]+)=(\"(?:[^\"]|\"\")+\"|[^,]+))+";
         Pattern pattern = Pattern.compile(patternRegex);
         Matcher matcher = pattern.matcher(name);
         boolean valid = false;


### PR DESCRIPTION
Even older Android devices (SDK22) still crash at regex pattern compilation with Syntax error in regexp pattern near index 17: (?:^|,\s?)(?:(?<name>[A-Z]+)=(?<val>"(?:[^"]|"")+"|[^,]+))+

**Description**
It's just an addition to tshakesp's commit 775e2bb0aca4e6465e2266c3539cae5e1202813d removing named groups in the regex.
