### PR TITLE
fix: change `value` to `amountValue` in adyen.model.nexo.amount

### DIFF
--- a/src/main/java/com/adyen/model/nexo/Amount.java
+++ b/src/main/java/com/adyen/model/nexo/Amount.java
@@ -4,7 +4,6 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
 import java.math.BigDecimal;
 
 
@@ -27,15 +26,16 @@ import java.math.BigDecimal;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Amount", propOrder = {
-        "value"
+        "amountValue",
+        "currency"
 })
 public class Amount {
 
     /**
      * The Value.
      */
-    @XmlValue
-    protected BigDecimal value;
+    @XmlAttribute(name = "AmountValue")
+    protected BigDecimal amountValue;
     /**
      * The Currency.
      */
@@ -43,21 +43,21 @@ public class Amount {
     protected String currency;
 
     /**
-     * Gets the value of the value property.
+     * Gets the value of the amountValue property.
      *
      * @return possible      object is     {@link BigDecimal }
      */
-    public BigDecimal getValue() {
-        return value;
+    public BigDecimal getAmountValue() {
+        return amountValue;
     }
 
     /**
-     * Sets the value of the value property.
+     * Sets the value of the amountValue property.
      *
      * @param value allowed object is     {@link BigDecimal }
      */
-    public void setValue(BigDecimal value) {
-        this.value = value;
+    public void setAmountValue(BigDecimal value) {
+        this.amountValue = value;
     }
 
     /**

--- a/src/test/java/com/adyen/TerminalCloudAPITest.java
+++ b/src/test/java/com/adyen/TerminalCloudAPITest.java
@@ -158,6 +158,16 @@ public class TerminalCloudAPITest extends BaseTest {
         assertNotNull(paymentResult.getAmountsResp());
         assertEquals("EUR", paymentResult.getAmountsResp().getCurrency());
         assertEquals(BigDecimal.ONE, paymentResult.getAmountsResp().getAuthorizedAmount());
+
+        assertNotNull(paymentResult.getCurrencyConversion());
+        assertNotNull(paymentResult.getCurrencyConversion().get(0));
+        assertTrue(paymentResult.getCurrencyConversion().get(0).isCustomerApprovedFlag());
+        assertEquals(new BigDecimal("3"), paymentResult.getCurrencyConversion().get(0).getMarkup());
+        assertEquals(new BigDecimal("0.035"), paymentResult.getCurrencyConversion().get(0).getRate());
+        assertNotNull(paymentResult.getCurrencyConversion().get(0).getConvertedAmount());
+        assertEquals(new BigDecimal("48.32"), paymentResult.getCurrencyConversion().get(0).getConvertedAmount().getAmountValue());
+        assertEquals("EUR", paymentResult.getCurrencyConversion().get(0).getConvertedAmount().getCurrency());
+
     }
 
     /**

--- a/src/test/resources/mocks/terminal-api/payment-sync-success.json
+++ b/src/test/resources/mocks/terminal-api/payment-sync-success.json
@@ -283,6 +283,17 @@
           },
           "MerchantID": "TestMerchant"
         },
+        "CurrencyConversion": [
+          {
+            "ConvertedAmount": {
+              "AmountValue": 48.32,
+              "Currency": "EUR"
+            },
+            "CustomerApprovedFlag": true,
+            "Markup": 3,
+            "Rate": 0.035
+          }
+        ],
         "PaymentInstrumentData": {
           "CardData": {
             "EntryMode": [


### PR DESCRIPTION
**Description**
current structure according to: https://docs.adyen.com/point-of-sale/terminal-api-reference#comadyennexoconvertedamount

**Fixed issue**: ConvertedAmount could not be deserialized correctly(amountValue was missing)
