### PR TITLE
fix: add `paymentReceipt` to StoredValueResponse

### DIFF
--- a/src/main/java/com/adyen/model/nexo/StoredValueResponse.java
+++ b/src/main/java/com/adyen/model/nexo/StoredValueResponse.java
@@ -35,7 +35,8 @@ import java.util.List;
         "response",
         "saleData",
         "poiData",
-        "storedValueResult"
+        "storedValueResult",
+        "paymentReceipt"
 })
 public class StoredValueResponse {
 
@@ -59,6 +60,12 @@ public class StoredValueResponse {
      */
     @XmlElement(name = "StoredValueResult")
     protected List<StoredValueResult> storedValueResult;
+    /**
+     * The Payment receipt.
+     */
+    @XmlElement(name = "PaymentReceipt")
+    protected List<PaymentReceipt> paymentReceipt;
+
 
     /**
      * Gets the value of the response property.
@@ -113,7 +120,6 @@ public class StoredValueResponse {
     public void setPOIData(POIData value) {
         this.poiData = value;
     }
-
     /**
      * Gets the value of the storedValueResult property.
      *
@@ -142,5 +148,14 @@ public class StoredValueResponse {
         }
         return this.storedValueResult;
     }
+
+    public List<PaymentReceipt> getPaymentReceipt() {
+        return paymentReceipt;
+    }
+
+    public void setPaymentReceipt(List<PaymentReceipt> paymentReceipt) {
+        this.paymentReceipt = paymentReceipt;
+    }
+
 
 }

--- a/src/test/java/com/adyen/TerminalCloudAPITest.java
+++ b/src/test/java/com/adyen/TerminalCloudAPITest.java
@@ -217,4 +217,75 @@ public class TerminalCloudAPITest extends BaseTest {
         assertNotNull(requestResponse.getSaleToPOIResponse().getInputResponse().getInputResult().getInput().getMenuEntryNumber());
         assertEquals(2, requestResponse.getSaleToPOIResponse().getInputResponse().getInputResult().getInput().getMenuEntryNumber().length);
     }
+
+    /**
+     * Mocked response for stored value type for POST /sync
+     */
+    @Test
+    public void syncPaymentRequestStoredValueSuccess() throws Exception {
+        Client client = createMockClientFromFile("mocks/terminal-api/payment-sync-success-storedvalue.json");
+        TerminalCloudAPI terminalCloudApi = new TerminalCloudAPI(client);
+
+        TerminalAPIRequest terminalAPIPaymentRequest = createTerminalAPIPaymentRequest();
+
+        // add some data
+        SaleToPOIRequest saleToPOIRequest = new SaleToPOIRequest();
+        PaymentRequest paymentRequest = new PaymentRequest();
+        SaleData saleDataRequest = new SaleData();
+        SaleToAcquirerData saleToAcquirerData = new SaleToAcquirerData();
+        saleDataRequest.setSaleToAcquirerData(saleToAcquirerData);
+        paymentRequest.setSaleData(saleDataRequest);
+        saleToPOIRequest.setPaymentRequest(paymentRequest);
+        terminalAPIPaymentRequest.setSaleToPOIRequest(saleToPOIRequest);
+
+        TerminalAPIResponse terminalAPIResponse = terminalCloudApi.sync(terminalAPIPaymentRequest);
+
+        assertNotNull(terminalAPIResponse);
+        assertNotNull(terminalAPIResponse.getSaleToPOIResponse());
+
+        SaleToPOIResponse saleToPoiResponse = terminalAPIResponse.getSaleToPOIResponse();
+        assertNotNull(saleToPoiResponse.getMessageHeader());
+        assertNotNull(saleToPoiResponse.getStoredValueResponse());
+
+        MessageHeader messageHeader = saleToPoiResponse.getMessageHeader();
+        assertEquals(MessageType.RESPONSE, messageHeader.getMessageType());
+        assertEquals(MessageClassType.SERVICE, messageHeader.getMessageClass());
+        assertEquals(MessageCategoryType.STORED_VALUE, messageHeader.getMessageCategory());
+        assertEquals("3.0", messageHeader.getProtocolVersion());
+        assertEquals("001", messageHeader.getSaleID());
+        assertEquals("1234567890", messageHeader.getServiceID());
+        assertEquals("P400Plus-123456789", messageHeader.getPOIID());
+
+        assertNotNull(saleToPoiResponse.getStoredValueResponse().getResponse());
+        Response response = saleToPoiResponse.getStoredValueResponse().getResponse();
+        assertEquals(ResultType.SUCCESS, response.getResult());
+        assertNotNull(response.getAdditionalResponse());
+
+        assertNotNull(saleToPoiResponse.getStoredValueResponse().getPOIData());
+        POIData poiData = saleToPoiResponse.getStoredValueResponse().getPOIData();
+        assertEquals("1000", poiData.getPOIReconciliationID());
+        assertNotNull(poiData.getPOITransactionID());
+        assertEquals("4r7i001556529591000.8515565295894301", poiData.getPOITransactionID().getTransactionID());
+        assertEquals("2019-04-29T00:00:00.000Z", poiData.getPOITransactionID().getTimeStamp().toString());
+
+        assertNotNull(saleToPoiResponse.getStoredValueResponse().getSaleData());
+        SaleData saleData = saleToPoiResponse.getStoredValueResponse().getSaleData();
+        assertNotNull(saleData.getSaleTransactionID());
+        assertEquals("001", saleData.getSaleTransactionID().getTransactionID());
+        assertEquals("2019-04-29T00:00:00.000Z", saleData.getSaleTransactionID().getTimeStamp().toString());
+
+        assertNotNull(saleToPoiResponse.getStoredValueResponse().getPaymentReceipt());
+        assertFalse(saleToPoiResponse.getStoredValueResponse().getPaymentReceipt().isEmpty());
+        List<PaymentReceipt> paymentReceiptList = saleToPoiResponse.getStoredValueResponse().getPaymentReceipt();
+        for (PaymentReceipt paymentReceipt : paymentReceiptList) {
+            assertNotNull(paymentReceipt.getDocumentQualifier());
+            assertNotNull(paymentReceipt.getOutputContent());
+            assertEquals(OutputFormatType.TEXT, paymentReceipt.getOutputContent().getOutputFormat());
+            assertNotNull(paymentReceipt.getOutputContent().getOutputText());
+            assertFalse(paymentReceipt.getOutputContent().getOutputText().isEmpty());
+            List<OutputText> outputTextList = paymentReceipt.getOutputContent().getOutputText();
+
+            outputTextList.forEach(outputText -> assertNotNull(outputText.getText()));
+        }
+    }
 }

--- a/src/test/resources/mocks/terminal-api/payment-sync-success-storedvalue.json
+++ b/src/test/resources/mocks/terminal-api/payment-sync-success-storedvalue.json
@@ -1,0 +1,262 @@
+{
+	"SaleToPOIResponse": {
+		"StoredValueResponse": {
+			"POIData": {
+				"POITransactionID": {
+					"TimeStamp": "2019-04-29T00:00:00.000Z",
+					"TransactionID": "4r7i001556529591000.8515565295894301"
+				},
+				"POIReconciliationID": "1000"
+			},
+			"SaleData": {
+				"SaleTransactionID": {
+					"TimeStamp": "2019-04-29T00:00:00.000Z",
+					"TransactionID": "001"
+				}
+			},
+			"PaymentReceipt": [{
+					"RequiredSignatureFlag": false,
+					"DocumentQualifier": "CashierReceipt",
+					"OutputContent": {
+						"OutputFormat": "Text",
+						"OutputText": [{
+								"CharacterStyle": "Bold",
+								"Text": "key=header1",
+								"EndOfLineFlag": true
+							},
+							{
+								"CharacterStyle": "Bold",
+								"Text": "key=header2",
+								"EndOfLineFlag": true
+							},
+							{
+								"CharacterStyle": "Bold",
+								"Text": "name=MERCHANT%20COPY&key=merchantTitle",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "key=filler",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Date&value=29%2f04%2f19&key=txdate",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Time&value=10%3a19%3a51&key=txtime",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "key=filler",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Card&value=%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a3511&key=pan",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Pref.%20name&value=MCC%20351%20v1%202&key=preferredName",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Card%20type&value=mc&key=cardType",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Payment%20method&value=mc&key=paymentMethod",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Payment%20variant&value=mc&key=paymentMethodVariant",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Entry%20mode&value=Contactless%20swipe&key=posEntryMode",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "key=filler",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=AID&value=A0000000041010&key=aid",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=MID&value=1000&key=mid",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=TID&value=P400Plus-1123456789&key=tid",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=PTID&value=75039202&key=ptid",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "key=filler",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Auth.%20code&value=123456&key=authCode",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Tender&value=4r7i001556529591000&key=txRef",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Reference&value=003&key=mref",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "key=filler",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "name=Type&value=GOODS_SERVICES&key=txtype",
+								"EndOfLineFlag": true
+							},
+							{
+								"CharacterStyle": "Bold",
+								"Text": "name=TOTAL&value=%e2%82%ac%c2%a01.00&key=totalAmount",
+								"EndOfLineFlag": true
+							},
+							{
+								"Text": "key=filler",
+								"EndOfLineFlag": true
+							},
+							{
+								"CharacterStyle": "Bold",
+								"Text": "name=APPROVED&key=approved",
+								"EndOfLineFlag": true
+							}
+						]
+					}
+				},
+				{
+					"DocumentQualifier": "CustomerReceipt",
+					"OutputContent": {
+						"OutputFormat": "Text",
+						"OutputText": [{
+							"CharacterStyle": "Bold",
+							"Text": "key=header1",
+							"EndOfLineFlag": true
+						}, {
+							"CharacterStyle": "Bold",
+							"Text": "key=header2",
+							"EndOfLineFlag": true
+						}, {
+							"CharacterStyle": "Bold",
+							"Text": "name=CARDHOLDER%20COPY&key=cardholderHeader",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "key=filler",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Date&value=31%2f05%2f2021&key=txdate",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Time&value=17%3a32%3a19&key=txtime",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "key=filler",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Card&value=%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a%2a1896&key=pan",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Card%20type&value=givex&key=cardType",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Payment%20method&value=givex&key=paymentMethod",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Entry%20mode&value=MKE&key=posEntryMode",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "key=filler",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=TID&value=P400Plus-803566352&key=tid",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=PTID&value=62050590&key=ptid",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "key=filler",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Auth.%20code&value=948684&key=authCode",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Tender&value=CMBy001622475139003&key=txRef",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Reference&value=00000100120210531183208&key=mref",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "key=filler",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Type&value=GOODS_SERVICES&key=txtype",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Balance&value=%e2%82%ac%2061%2c00&key=currentBalanceAmount",
+							"EndOfLineFlag": true
+						}, {
+							"CharacterStyle": "Bold",
+							"Text": "name=TOTAL&value=%e2%82%ac%2010%2c00&key=totalAmount",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "key=filler",
+							"EndOfLineFlag": true
+						}, {
+							"CharacterStyle": "Bold",
+							"Text": "name=APPROVED&key=approved",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "key=filler",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Retain%20for%20your%20records&key=retain",
+							"EndOfLineFlag": true
+						}, {
+							"Text": "name=Thank%20you&key=thanks",
+							"EndOfLineFlag": true
+						}]
+					}
+				}
+			],
+			"StoredValueResult": [{
+				"StoredValueTransactionType": "Load",
+				"ItemAmount": 10,
+				"StoredValueAccountStatus": {
+					"StoredValueAccountID": {
+						"IdentificationType": "PAN",
+						"EntryMode": ["Scanned"],
+						"StoredValueID": "storedvalueidnumber",
+						"StoredValueAccountType": "GiftCard",
+						"StoredValueProvider": "givex"
+					},
+					"CurrentBalance": 61
+				},
+				"Currency": "EUR"
+			}],
+			"Response": {
+				"Result": "Success",
+				"AdditionalResponse": "....."
+			}
+		},
+		"MessageHeader": {
+			"ProtocolVersion": "3.0",
+			"SaleID": "001",
+			"MessageClass": "Service",
+			"MessageCategory": "StoredValue",
+			"ServiceID": "1234567890",
+			"POIID": "P400Plus-123456789",
+			"MessageType": "Response"
+		}
+	}
+}


### PR DESCRIPTION
**Description**
adding paymentReceipt in storedValueResponse as explained here https://docs.adyen.com/point-of-sale/terminal-api-reference#comadyennexostoredvalueresponse
