### PR TITLE
HTTP Client wrong encoding

### DIFF
--- a/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
+++ b/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
@@ -29,12 +29,7 @@ import com.adyen.terminal.security.TerminalCommonNameValidator;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.*;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.StringEntity;
@@ -42,13 +37,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.*;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URI;
@@ -59,12 +49,7 @@ import java.security.cert.X509Certificate;
 import java.util.Map;
 
 import static com.adyen.constants.ApiConstants.HttpMethod.POST;
-import static com.adyen.constants.ApiConstants.RequestProperty.ACCEPT_CHARSET;
-import static com.adyen.constants.ApiConstants.RequestProperty.API_KEY;
-import static com.adyen.constants.ApiConstants.RequestProperty.APPLICATION_JSON_TYPE;
-import static com.adyen.constants.ApiConstants.RequestProperty.CONTENT_TYPE;
-import static com.adyen.constants.ApiConstants.RequestProperty.IDEMPOTENCY_KEY;
-import static com.adyen.constants.ApiConstants.RequestProperty.USER_AGENT;
+import static com.adyen.constants.ApiConstants.RequestProperty.*;
 
 public class AdyenHttpClient implements ClientInterface {
 
@@ -150,25 +135,21 @@ public class AdyenHttpClient implements ClientInterface {
         }
     }
 
-    private HttpRequestBase createHttpRequestBase(URI endpoint, String requestBody, ApiConstants.HttpMethod httpMethod) throws HTTPClientException {
-        try {
-            switch (httpMethod) {
-                case GET:
-                    return new HttpGet(endpoint);
-                case PATCH:
-                    HttpPatch httpPatch = new HttpPatch(endpoint);
-                    httpPatch.setEntity(new StringEntity(requestBody));
-                    return httpPatch;
-                case DELETE:
-                    new HttpDelete(endpoint);
-                default:
-                    // Default to POST if httpMethod is not provided
-                    HttpPost httpPost = new HttpPost(endpoint);
-                    httpPost.setEntity(new StringEntity(requestBody));
-                    return httpPost;
-            }
-        }  catch (UnsupportedEncodingException e) {
-            throw new HTTPClientException("Unsupported encoding", e);
+    private HttpRequestBase createHttpRequestBase(URI endpoint, String requestBody, ApiConstants.HttpMethod httpMethod) {
+        switch (httpMethod) {
+            case GET:
+                return new HttpGet(endpoint);
+            case PATCH:
+                HttpPatch httpPatch = new HttpPatch(endpoint);
+                httpPatch.setEntity(new StringEntity(requestBody, CHARSET));
+                return httpPatch;
+            case DELETE:
+                return new HttpDelete(endpoint);
+            default:
+                // Default to POST if httpMethod is not provided
+                HttpPost httpPost = new HttpPost(endpoint);
+                httpPost.setEntity(new StringEntity(requestBody, CHARSET));
+                return httpPost;
         }
     }
 

--- a/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
+++ b/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
@@ -29,7 +29,12 @@ import com.adyen.terminal.security.TerminalCommonNameValidator;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.*;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.StringEntity;
@@ -37,7 +42,11 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
-import javax.net.ssl.*;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -49,7 +58,12 @@ import java.security.cert.X509Certificate;
 import java.util.Map;
 
 import static com.adyen.constants.ApiConstants.HttpMethod.POST;
-import static com.adyen.constants.ApiConstants.RequestProperty.*;
+import static com.adyen.constants.ApiConstants.RequestProperty.ACCEPT_CHARSET;
+import static com.adyen.constants.ApiConstants.RequestProperty.API_KEY;
+import static com.adyen.constants.ApiConstants.RequestProperty.APPLICATION_JSON_TYPE;
+import static com.adyen.constants.ApiConstants.RequestProperty.CONTENT_TYPE;
+import static com.adyen.constants.ApiConstants.RequestProperty.IDEMPOTENCY_KEY;
+import static com.adyen.constants.ApiConstants.RequestProperty.USER_AGENT;
 
 public class AdyenHttpClient implements ClientInterface {
 


### PR DESCRIPTION
**Description**
The Apache Http client uses the ISO-8859-1 encoding for request bodies. This is not compatible with the rest endpoint and the encoding declared in the header of the request (UTF-8).

**Fixed issue**:  #565 
