### PR TITLE
Use KeyStore.getDefaultType()

### DIFF
--- a/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
+++ b/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
@@ -70,7 +70,6 @@ public class AdyenHttpClient implements ClientInterface {
 
     private static final String CHARSET = "UTF-8";
     private static final String TERMINAL_CERTIFICATE_ALIAS = "TerminalCertificate";
-    private static final String JAVA_KEYSTORE = "JKS";
     private static final String SSL = "SSL";
     private Proxy proxy;
 
@@ -193,7 +192,7 @@ public class AdyenHttpClient implements ClientInterface {
             HttpClientBuilder httpClientBuilder = HttpClients.custom();
             // Create new KeyStore for the terminal certificate
             try {
-                KeyStore keyStore = KeyStore.getInstance(JAVA_KEYSTORE);
+                KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
                 keyStore.load(null, null);
                 keyStore.setCertificateEntry(TERMINAL_CERTIFICATE_ALIAS, config.getTerminalCertificate());
 


### PR DESCRIPTION
Android throws `java.security.KeyStoreException: JKS not found` as it (the Dalvik virtual machine) does not provide JKS key store type. Please, see KeyStore description at https://developer.android.com/reference/java/security/KeyStore

The call to KeyStore.getDefaultType() was used in HttpURLConnectionClient.java until the refactor to AdyenHttpClient.java in 15.0.0 where it was replaced with the JAVA_KEYSTORE constant. Please, keep using KeyStore.getDefaultType().

**See:**
https://github.com/Adyen/adyen-java-api-library/blob/14.0.0/src/main/java/com/adyen/httpclient/HttpURLConnectionClient.java
https://github.com/Adyen/adyen-java-api-library/blob/15.0.0/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
