### PR TITLE
FOC-47780: Update TerminalCommonNameValidator to support validation of Castles certificates

### DIFF
--- a/src/main/java/com/adyen/terminal/security/TerminalCommonNameValidator.java
+++ b/src/main/java/com/adyen/terminal/security/TerminalCommonNameValidator.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 public final class TerminalCommonNameValidator {
 
     private static final String ENVIRONMENT_WILDCARD = "{ENVIRONMENT}";
-    private static final String TERMINAL_API_CN_REGEX = "[a-zA-Z0-9]{4,}-[0-9]{9}\\." + ENVIRONMENT_WILDCARD + "\\.terminal\\.adyen\\.com";
+    private static final String TERMINAL_API_CN_REGEX = "[a-zA-Z0-9]{3,}-[0-9]{9,15}\\." + ENVIRONMENT_WILDCARD + "\\.terminal\\.adyen\\.com";
     private static final String TERMINAL_API_LEGACY_CN = "legacy-terminal-certificate." + ENVIRONMENT_WILDCARD + ".terminal.adyen.com";
 
     private TerminalCommonNameValidator() {
@@ -47,8 +47,9 @@ public final class TerminalCommonNameValidator {
             String groupName = matcher.group(1);
             if ("CN".equals(groupName)) {
                 String commonName = matcher.group(2);
-                valid = commonName.matches(TERMINAL_API_CN_REGEX.replace(ENVIRONMENT_WILDCARD, environmentName))
-                        || commonName.equals(TERMINAL_API_LEGACY_CN.replace(ENVIRONMENT_WILDCARD, environmentName));
+                valid = commonName != null
+                        && (commonName.matches(TERMINAL_API_CN_REGEX.replace(ENVIRONMENT_WILDCARD, environmentName))
+                        || commonName.equals(TERMINAL_API_LEGACY_CN.replace(ENVIRONMENT_WILDCARD, environmentName)));
             }
         }
 

--- a/src/test/java/com/adyen/terminal/security/TerminalCommonNameValidatorTest.java
+++ b/src/test/java/com/adyen/terminal/security/TerminalCommonNameValidatorTest.java
@@ -49,11 +49,15 @@ public class TerminalCommonNameValidatorTest {
                 { "EMAILADDRESS=mock@adyen.com, CN=legacy-terminal-certificate.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.LIVE, true },
                 { "EMAILADDRESS=mock@adyen.com, CN=P400-123456789.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.TEST, true },
                 { "EMAILADDRESS=mock@adyen.com, CN=P400-123456789.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.LIVE, true },
+                { "EMAILADDRESS=mock@adyen.com, CN=S1E-000150123456789.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.TEST, true },
+                { "EMAILADDRESS=mock@adyen.com, CN=S1E-000150123456789.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.LIVE, true },
                 // Wrong environment
                 { "EMAILADDRESS=mock@adyen.com, CN=legacy-terminal-certificate.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.LIVE, false },
                 { "EMAILADDRESS=mock@adyen.com, CN=P400-123456789.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.LIVE, false },
+                { "EMAILADDRESS=mock@adyen.com, CN=S1E-000150123456789.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.LIVE, false },
                 { "EMAILADDRESS=mock@adyen.com, CN=legacy-terminal-certificate.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.TEST, false },
                 { "EMAILADDRESS=mock@adyen.com, CN=P400-123456789.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.TEST, false },
+                { "EMAILADDRESS=mock@adyen.com, CN=S1E-000150123456789.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.TEST, false },
                 // Invalid CN
                 { "EMAILADDRESS=mock@adyen.com, CN=wrong-terminal-certificate.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.TEST, false },
                 { "EMAILADDRESS=mock@adyen.com, CN=legacyy-terminal-certificate.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Environment.TEST, false },


### PR DESCRIPTION
**Description**
TerminalCommonNameValidator does not support certificates from Castles terminals. Updated the logic in the following way:
- Minimum length of terminal model name has been changed from 4 to 3 characters (to account for `S1E`)
- Changed regular expression for serial number to allow a range from 9 to 15 digits (to account for all Castles serial numbers)
- Added a `null` check for return value from `Matcher.group(int)`

**Tested scenarios**
Added tests for `S1E` CN.

**Fixed issue**:  Partially FOC-47780