### PR TITLE
Add support for UltimateParentCompany

### DIFF
--- a/src/main/java/com/adyen/model/marketpay/BusinessDetails.java
+++ b/src/main/java/com/adyen/model/marketpay/BusinessDetails.java
@@ -63,6 +63,9 @@ public class BusinessDetails {
     @SerializedName("taxId")
     private String taxId = null;
 
+    @SerializedName("listedUltimateParentCompany")
+    private List<UltimateParentCompany> listedUltimateParentCompany = null;
+
     public BusinessDetails doingBusinessAs(String doingBusinessAs) {
         this.doingBusinessAs = doingBusinessAs;
         return this;
@@ -259,6 +262,32 @@ public class BusinessDetails {
         this.stockTicker = stockTicker;
     }
 
+    /**
+     * Information about the parent public company. Required if the account holder is 100% owned by a publicly listed
+     * company.
+     *
+     * @return listedUltimateParentCompany
+     */
+    public List<UltimateParentCompany> getListedUltimateParentCompany() {
+        return listedUltimateParentCompany;
+    }
+
+    public void setListedUltimateParentCompany(List<UltimateParentCompany> listedUltimateParentCompany) {
+        this.listedUltimateParentCompany = listedUltimateParentCompany;
+    }
+
+    public BusinessDetails listedUltimateParentCompany(List<UltimateParentCompany> listedUltimateParentCompany) {
+        this.listedUltimateParentCompany = listedUltimateParentCompany;
+        return this;
+    }
+
+    public BusinessDetails addListedUltimateParentCompanyItem(UltimateParentCompany listedUltimateParentCompanyItem) {
+        if (this.listedUltimateParentCompany == null) {
+            this.listedUltimateParentCompany = new ArrayList<>();
+        }
+        this.listedUltimateParentCompany.add(listedUltimateParentCompanyItem);
+        return this;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -278,12 +307,13 @@ public class BusinessDetails {
                 Objects.equals(this.stockExchange, businessDetails.stockExchange) &&
                 Objects.equals(this.stockNumber, businessDetails.stockNumber) &&
                 Objects.equals(this.stockTicker, businessDetails.stockTicker) &&
-                Objects.equals(this.taxId, businessDetails.taxId);
+                Objects.equals(this.taxId, businessDetails.taxId) &&
+                Objects.equals(this.listedUltimateParentCompany, businessDetails.listedUltimateParentCompany);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(doingBusinessAs, incorporatedAt, legalBusinessName, registrationNumber, shareholders, signatories, stockExchange, stockNumber, stockTicker, taxId);
+        return Objects.hash(doingBusinessAs, incorporatedAt, legalBusinessName, registrationNumber, shareholders, signatories, stockExchange, stockNumber, stockTicker, taxId, listedUltimateParentCompany);
     }
 
 
@@ -302,6 +332,7 @@ public class BusinessDetails {
         sb.append("    stockNumber: ").append(toIndentedString(stockNumber)).append("\n");
         sb.append("    stockTicker: ").append(toIndentedString(stockTicker)).append("\n");
         sb.append("    taxId: ").append(toIndentedString(taxId)).append("\n");
+        sb.append("    listedUltimateParentCompany: ").append(toIndentedString(listedUltimateParentCompany)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/src/main/java/com/adyen/model/marketpay/FieldType.java
+++ b/src/main/java/com/adyen/model/marketpay/FieldType.java
@@ -25,7 +25,6 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.Objects;
 
-
 import static com.adyen.util.Util.toIndentedString;
 
 /**
@@ -194,6 +193,39 @@ public class FieldType {
 
         @SerializedName("tierNumber")
         TIERNUMBER("tierNumber"),
+
+        @SerializedName("ultimateParentCompany")
+        ULTIMATEPARENTCOMPANY("ultimateParentCompany"),
+
+        @SerializedName("ultimateParentCompanyAddressDetails")
+        ULTIMATEPARENTCOMPANYADDRESSDETAILS("ultimateParentCompanyAddressDetails"),
+
+        @SerializedName("ultimateParentCompanyAddressDetailsCountry")
+        ULTIMATEPARENTCOMPANYADDRESSDETAILSCOUNTRY("ultimateParentCompanyAddressDetailsCountry"),
+
+        @SerializedName("ultimateParentCompanyBusinessDetails")
+        ULTIMATEPARENTCOMPANYBUSINESSDETAILS("ultimateParentCompanyBusinessDetails"),
+
+        @SerializedName("ultimateParentCompanyBusinessDetailsLegalBusinessName")
+        ULTIMATEPARENTCOMPANYBUSINESSDETAILSLEGALBUSINESSNAME("ultimateParentCompanyBusinessDetailsLegalBusinessName"),
+
+        @SerializedName("ultimateParentCompanyBusinessDetailsRegistrationNumber")
+        ULTIMATEPARENTCOMPANYBUSINESSDETAILSREGISTRATIONNUMBER("ultimateParentCompanyBusinessDetailsRegistrationNumber"),
+
+        @SerializedName("ultimateParentCompanyCode")
+        ULTIMATEPARENTCOMPANYCODE("ultimateParentCompanyCode"),
+
+        @SerializedName("ultimateParentCompanyStockExchange")
+        ULTIMATEPARENTCOMPANYSTOCKEXCHANGE("ultimateParentCompanyStockExchange"),
+
+        @SerializedName("ultimateParentCompanyStockNumber")
+        ULTIMATEPARENTCOMPANYSTOCKNUMBER("ultimateParentCompanyStockNumber"),
+
+        @SerializedName("ultimateParentCompanyStockNumberOrStockTicker")
+        ULTIMATEPARENTCOMPANYSTOCKNUMBERORSTOCKTICKER("ultimateParentCompanyStockNumberOrStockTicker"),
+
+        @SerializedName("ultimateParentCompanyStockTicker")
+        ULTIMATEPARENTCOMPANYSTOCKTICKER("ultimateParentCompanyStockTicker"),
 
         @SerializedName("unknown")
         UNKNOWN("unknown"),

--- a/src/main/java/com/adyen/model/marketpay/KYCUltimateParentCompanyCheckResult.java
+++ b/src/main/java/com/adyen/model/marketpay/KYCUltimateParentCompanyCheckResult.java
@@ -1,0 +1,115 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Java API Library
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+package com.adyen.model.marketpay;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static com.adyen.util.Util.toIndentedString;
+
+/**
+ * KYCUltimateParentCompanyCheckResult
+ */
+public class KYCUltimateParentCompanyCheckResult {
+    @SerializedName("checks")
+    private List<KYCCheckStatusData> checks = new ArrayList<>();
+
+    @SerializedName("ultimateParentCompanyCode")
+    private String ultimateParentCompanyCode = null;
+
+    public KYCUltimateParentCompanyCheckResult checkStatusData(List<KYCCheckStatusData> checkStatusData) {
+        this.checks = checkStatusData;
+        return this;
+    }
+
+    public KYCUltimateParentCompanyCheckResult addCheckStatusDataItem(KYCCheckStatusData checkStatusDataItem) {
+        this.checks.add(checkStatusDataItem);
+        return this;
+    }
+
+    /**
+     * A list of the checks and their statuses.
+     *
+     * @return checks
+     **/
+    public List<KYCCheckStatusData> getChecks() {
+        return checks;
+    }
+
+    public void setChecks(List<KYCCheckStatusData> checks) {
+        this.checks = checks;
+    }
+
+    public KYCUltimateParentCompanyCheckResult ultimateParentCompanyCode(String ultimateParentCompanyCode) {
+        this.ultimateParentCompanyCode = ultimateParentCompanyCode;
+        return this;
+    }
+
+    /**
+     * The code of the Ultimate Parent Company to which the check applies.
+     *
+     * @return ultimateParentCompanyCode
+     **/
+    public String getUltimateParentCompanyCode() {
+        return ultimateParentCompanyCode;
+    }
+
+    public void setUltimateParentCompanyCode(String ultimateParentCompanyCode) {
+        this.ultimateParentCompanyCode = ultimateParentCompanyCode;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KYCUltimateParentCompanyCheckResult kYCUltimateParentCompanyCheckResult = (KYCUltimateParentCompanyCheckResult) o;
+        return Objects.equals(this.checks, kYCUltimateParentCompanyCheckResult.checks) &&
+                Objects.equals(this.ultimateParentCompanyCode, kYCUltimateParentCompanyCheckResult.ultimateParentCompanyCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(checks, ultimateParentCompanyCode);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class KYCUltimateParentCompanyCheckResult {\n");
+
+        sb.append("    checks: ").append(toIndentedString(checks)).append("\n");
+        sb.append("    ultimateParentCompanyCode: ").append(toIndentedString(ultimateParentCompanyCode)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+
+
+}
+

--- a/src/main/java/com/adyen/model/marketpay/KYCVerificationResult.java
+++ b/src/main/java/com/adyen/model/marketpay/KYCVerificationResult.java
@@ -20,9 +20,10 @@
  */
 package com.adyen.model.marketpay;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.ArrayList;
 import java.util.List;
-import com.google.gson.annotations.SerializedName;
 
 /**
  * KYCVerificationResult
@@ -39,6 +40,9 @@ public class KYCVerificationResult {
 
     @SerializedName("payoutMethods")
     private List<KYCPayoutMethodCheckResult> payoutMethods = new ArrayList<>();
+
+    @SerializedName("ultimateParentCompany")
+    private List<KYCUltimateParentCompanyCheckResult> ultimateParentCompany = new ArrayList<>();
 
     public List<KYCShareholderCheckResult> getShareholders() {
         return shareholders;
@@ -72,8 +76,16 @@ public class KYCVerificationResult {
         this.payoutMethods = payoutMethods;
     }
 
+    public List<KYCUltimateParentCompanyCheckResult> getUltimateParentCompany() {
+        return ultimateParentCompany;
+    }
+
+    public void setUltimateParentCompany(List<KYCUltimateParentCompanyCheckResult> ultimateParentCompany) {
+        this.ultimateParentCompany = ultimateParentCompany;
+    }
+
     @Override
     public String toString() {
-        return "KYCVerificationResult{" + "shareholders=" + shareholders + ", accountHolder=" + accountHolder + ", bankAccounts=" + bankAccounts + ", payoutMethods=" + payoutMethods + '}';
+        return "KYCVerificationResult{" + "shareholders=" + shareholders + ", accountHolder=" + accountHolder + ", bankAccounts=" + bankAccounts + ", payoutMethods=" + payoutMethods + ", ultimateParentCompany=" + ultimateParentCompany + '}';
     }
 }

--- a/src/main/java/com/adyen/model/marketpay/UltimateParentCompany.java
+++ b/src/main/java/com/adyen/model/marketpay/UltimateParentCompany.java
@@ -1,0 +1,129 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Java API Library
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+package com.adyen.model.marketpay;
+
+import com.adyen.model.Address;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
+
+import static com.adyen.util.Util.toIndentedString;
+
+/**
+ * UltimateParentCompany
+ */
+public class UltimateParentCompany {
+    @SerializedName("address")
+    private Address address = null;
+
+    @SerializedName("businessDetails")
+    private BusinessDetails businessDetails = null;
+
+    @SerializedName("ultimateParentCompanyCode")
+    private String ultimateParentCompanyCode = null;
+
+    /**
+     * Address of the ultimate parent company.
+     *
+     * @return address
+     */
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public UltimateParentCompany address(Address address) {
+        this.address = address;
+        return this;
+    }
+
+    /**
+     * Details about the ultimate parent company's business.
+     *
+     * @return businessDetails
+     */
+    public BusinessDetails getBusinessDetails() {
+        return businessDetails;
+    }
+
+    public void setBusinessDetails(BusinessDetails businessDetails) {
+        this.businessDetails = businessDetails;
+    }
+
+    public UltimateParentCompany businessDetails(BusinessDetails businessDetails) {
+        this.businessDetails = businessDetails;
+        return this;
+    }
+
+    /**
+     * Adyen-generated unique alphanumeric identifier (UUID) for the entry, returned in the response when you create an
+     * ultimate parent company. Required when updating an existing entry in an /updateAccountHolder request.
+     *
+     * @return ultimateParentCompanyCode
+     */
+    public String getUltimateParentCompanyCode() {
+        return ultimateParentCompanyCode;
+    }
+
+    public void setUltimateParentCompanyCode(String ultimateParentCompanyCode) {
+        this.ultimateParentCompanyCode = ultimateParentCompanyCode;
+    }
+
+    public UltimateParentCompany ultimateParentCompanyCode(String ultimateParentCompanyCode) {
+        this.ultimateParentCompanyCode = ultimateParentCompanyCode;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UltimateParentCompany ultimateParentCompany = (UltimateParentCompany) o;
+        return Objects.equals(this.address, ultimateParentCompany.address) &&
+                Objects.equals(this.businessDetails, ultimateParentCompany.businessDetails) &&
+                Objects.equals(this.ultimateParentCompanyCode, ultimateParentCompany.ultimateParentCompanyCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address, businessDetails, ultimateParentCompanyCode);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UltimateParentCompany {\n");
+
+        sb.append("    address: ").append(toIndentedString(address)).append("\n");
+        sb.append("    businessDetails: ").append(toIndentedString(businessDetails)).append("\n");
+        sb.append("    ultimateParentCompanyCode: ").append(toIndentedString(ultimateParentCompanyCode)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/adyen/model/marketpay/UltimateParentCompany.java
+++ b/src/main/java/com/adyen/model/marketpay/UltimateParentCompany.java
@@ -36,7 +36,7 @@ public class UltimateParentCompany {
     private Address address = null;
 
     @SerializedName("businessDetails")
-    private BusinessDetails businessDetails = null;
+    private UltimateParentCompanyBusinessDetails businessDetails = null;
 
     @SerializedName("ultimateParentCompanyCode")
     private String ultimateParentCompanyCode = null;
@@ -64,15 +64,15 @@ public class UltimateParentCompany {
      *
      * @return businessDetails
      */
-    public BusinessDetails getBusinessDetails() {
+    public UltimateParentCompanyBusinessDetails getBusinessDetails() {
         return businessDetails;
     }
 
-    public void setBusinessDetails(BusinessDetails businessDetails) {
+    public void setBusinessDetails(UltimateParentCompanyBusinessDetails businessDetails) {
         this.businessDetails = businessDetails;
     }
 
-    public UltimateParentCompany businessDetails(BusinessDetails businessDetails) {
+    public UltimateParentCompany businessDetails(UltimateParentCompanyBusinessDetails businessDetails) {
         this.businessDetails = businessDetails;
         return this;
     }

--- a/src/main/java/com/adyen/model/marketpay/UltimateParentCompanyBusinessDetails.java
+++ b/src/main/java/com/adyen/model/marketpay/UltimateParentCompanyBusinessDetails.java
@@ -1,0 +1,175 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Java API Library
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+package com.adyen.model.marketpay;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
+
+import static com.adyen.util.Util.toIndentedString;
+
+/**
+ * UltimateParentCompanyBusinessDetails
+ */
+public class UltimateParentCompanyBusinessDetails {
+    @SerializedName("legalBusinessName")
+    private String legalBusinessName = null;
+
+    @SerializedName("registrationNumber")
+    private String registrationNumber = null;
+
+    @SerializedName("stockExchange")
+    private String stockExchange = null;
+
+    @SerializedName("stockNumber")
+    private String stockNumber = null;
+
+    @SerializedName("stockTicker")
+    private String stockTicker = null;
+
+
+    public UltimateParentCompanyBusinessDetails legalBusinessName(String legalBusinessName) {
+        this.legalBusinessName = legalBusinessName;
+        return this;
+    }
+
+    /**
+     * The legal name of the company.
+     *
+     * @return legalBusinessName
+     **/
+    public String getLegalBusinessName() {
+        return legalBusinessName;
+    }
+
+    public void setLegalBusinessName(String legalBusinessName) {
+        this.legalBusinessName = legalBusinessName;
+    }
+
+    public UltimateParentCompanyBusinessDetails registrationNumber(String registrationNumber) {
+        this.registrationNumber = registrationNumber;
+        return this;
+    }
+
+    /**
+     * The registration number of the company.
+     *
+     * @return registrationNumber
+     **/
+    public String getRegistrationNumber() {
+        return registrationNumber;
+    }
+
+    public void setRegistrationNumber(String registrationNumber) {
+        this.registrationNumber = registrationNumber;
+    }
+
+    public UltimateParentCompanyBusinessDetails stockExchange(String stockExchange) {
+        this.stockExchange = stockExchange;
+        return this;
+    }
+
+    /**
+     * Market Identifier Code (MIC)
+     *
+     * @return stockExchange
+     */
+    public String getStockExchange() {
+        return stockExchange;
+    }
+
+    public void setStockExchange(String stockExchange) {
+        this.stockExchange = stockExchange;
+    }
+
+    public UltimateParentCompanyBusinessDetails stockNumber(String stockNumber) {
+        this.stockNumber = stockNumber;
+        return this;
+    }
+
+    /**
+     * International Securities Identification Number (ISIN)
+     *
+     * @return stockNumber
+     */
+    public String getStockNumber() {
+        return stockNumber;
+    }
+
+    public void setStockNumber(String stockNumber) {
+        this.stockNumber = stockNumber;
+    }
+
+    public UltimateParentCompanyBusinessDetails stockTicker(String stockTicker) {
+        this.stockTicker = stockTicker;
+        return this;
+    }
+
+    /**
+     * Stock Ticker symbol.
+     *
+     * @return stockTicker
+     */
+    public String getStockTicker() {
+        return stockTicker;
+    }
+
+    public void setStockTicker(String stockTicker) {
+        this.stockTicker = stockTicker;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UltimateParentCompanyBusinessDetails businessDetails = (UltimateParentCompanyBusinessDetails) o;
+        return Objects.equals(this.legalBusinessName, businessDetails.legalBusinessName) &&
+                Objects.equals(this.registrationNumber, businessDetails.registrationNumber) &&
+                Objects.equals(this.stockExchange, businessDetails.stockExchange) &&
+                Objects.equals(this.stockNumber, businessDetails.stockNumber) &&
+                Objects.equals(this.stockTicker, businessDetails.stockTicker);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(legalBusinessName, registrationNumber, stockExchange, stockNumber, stockTicker);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UltimateParentCompanyBusinessDetails {\n");
+        sb.append("    legalBusinessName: ").append(toIndentedString(legalBusinessName)).append("\n");
+        sb.append("    registrationNumber: ").append(toIndentedString(registrationNumber)).append("\n");
+        sb.append("    stockExchange: ").append(toIndentedString(stockExchange)).append("\n");
+        sb.append("    stockNumber: ").append(toIndentedString(stockNumber)).append("\n");
+        sb.append("    stockTicker: ").append(toIndentedString(stockTicker)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+
+}

--- a/src/test/java/com/adyen/MarketPayTest.java
+++ b/src/test/java/com/adyen/MarketPayTest.java
@@ -111,8 +111,14 @@ import java.util.TimeZone;
 import static com.adyen.model.marketpay.AccountEvent.EventEnum.INACTIVATEACCOUNT;
 import static com.adyen.model.marketpay.KYCCheckStatusData.StatusEnum.AWAITING_DATA;
 import static com.adyen.model.marketpay.KYCCheckStatusData.StatusEnum.PASSED;
-import static com.adyen.model.marketpay.KYCCheckStatusData.TypeEnum.*;
-import static org.junit.Assert.*;
+import static com.adyen.model.marketpay.KYCCheckStatusData.TypeEnum.BANK_ACCOUNT_VERIFICATION;
+import static com.adyen.model.marketpay.KYCCheckStatusData.TypeEnum.COMPANY_VERIFICATION;
+import static com.adyen.model.marketpay.KYCCheckStatusData.TypeEnum.IDENTITY_VERIFICATION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for /authorise and /authorise3d
@@ -435,6 +441,32 @@ public class MarketPayTest extends BaseTest {
         assertEquals("Director", getAccountHolderResponse.getAccountHolderDetails().getBusinessDetails().getShareholders().get(0).getJobTitle());
         assertEquals("Director", getAccountHolderResponse.getAccountHolderDetails().getBusinessDetails().getSignatories().get(0).getJobTitle());
         assertEquals(ShareholderContact.ShareholderTypeEnum.CONTROLLER, getAccountHolderResponse.getAccountHolderDetails().getBusinessDetails().getShareholders().get(0).getShareholderType());
+    }
+
+    @Test
+    public void TestGetBusinessAccountHolderWithParentSuccess() throws Exception {
+        // setup client
+        Client client = createMockClientFromFile("mocks/marketpay/account/get-business-account-holder-with-parent-success.json");
+
+        // use Account service
+        Account account = new Account(client);
+
+        // create GetAccountHolder Request
+        GetAccountHolderRequest getAccountHolderRequest = new GetAccountHolderRequest();
+        getAccountHolderRequest.setAccountHolderCode("TestAccountHolderUltimateParentCompany");
+
+        GetAccountHolderResponse getAccountHolderResponse = account.getAccountHolder(getAccountHolderRequest);
+
+        assertEquals("TestAccountHolderUltimateParentCompany", getAccountHolderResponse.getAccountHolderCode());
+        assertEquals("25aee067-3560-4e16-83d6-0b6aa96e7e85", getAccountHolderResponse.getAccountHolderDetails().getBusinessDetails().getListedUltimateParentCompany().get(0).getUltimateParentCompanyCode());
+        assertEquals("UPC Test Street", getAccountHolderResponse.getAccountHolderDetails().getBusinessDetails().getListedUltimateParentCompany().get(0).getAddress().getStreet());
+
+        assertEquals(COMPANY_VERIFICATION, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getType());
+        assertEquals(PASSED, getAccountHolderResponse.getVerification().getAccountHolder().getChecks().get(0).getStatus());
+
+        assertEquals(COMPANY_VERIFICATION, getAccountHolderResponse.getVerification().getUltimateParentCompany().get(0).getChecks().get(0).getType());
+        assertEquals(PASSED, getAccountHolderResponse.getVerification().getUltimateParentCompany().get(0).getChecks().get(0).getStatus());
+        assertEquals("25aee067-3560-4e16-83d6-0b6aa96e7e85", getAccountHolderResponse.getVerification().getUltimateParentCompany().get(0).getUltimateParentCompanyCode());
     }
 
     @Test

--- a/src/test/resources/mocks/marketpay/account/get-business-account-holder-with-parent-success.json
+++ b/src/test/resources/mocks/marketpay/account/get-business-account-holder-with-parent-success.json
@@ -1,0 +1,103 @@
+{
+  "pspReference": "8816286790542602",
+  "accountHolderCode": "TestAccountHolderUltimateParentCompany",
+  "accountHolderDetails": {
+    "address": {
+      "city": "PASSED",
+      "country": "NL",
+      "houseNumberOrName": "2",
+      "postalCode": "4321AB",
+      "street": "Outer Test Street"
+    },
+    "bankAccountDetails": [],
+    "businessDetails": {
+      "legalBusinessName": "TestData",
+      "listedUltimateParentCompany": [
+        {
+          "address": {
+            "city": "PASSED",
+            "country": "NL",
+            "houseNumberOrName": "1",
+            "postalCode": "1234AB",
+            "street": "UPC Test Street"
+          },
+          "businessDetails": {
+            "legalBusinessName": "TestData",
+            "registrationNumber": "123456",
+            "stockExchange": "XAMS",
+            "stockNumber": "NL0012969182",
+            "stockTicker": "ADYEN"
+          },
+          "ultimateParentCompanyCode": "25aee067-3560-4e16-83d6-0b6aa96e7e85"
+        }
+      ],
+      "registrationNumber": "12345678"
+    },
+    "email": "support@adyen.com",
+    "legalArrangements": [],
+    "merchantCategoryCode": "7999",
+    "payoutMethods": [],
+    "webAddress": null
+  },
+  "accountHolderStatus": {
+    "status": "Active",
+    "processingState": {
+      "disabled": false,
+      "processedFrom": {
+        "currency": "EUR",
+        "value": 0
+      },
+      "processedTo": {
+        "currency": "EUR",
+        "value": 0
+      },
+      "tierNumber": 0
+    },
+    "payoutState": {
+      "allowPayout": true,
+      "payoutLimit": {
+        "currency": "EUR",
+        "value": 0
+      },
+      "disabled": false,
+      "tierNumber": 0
+    },
+    "events": []
+  },
+  "accounts": [
+    {
+      "accountCode": "8816286790475498",
+      "description": "TransactionAccount",
+      "payoutSchedule": {
+        "schedule": "DEFAULT"
+      },
+      "payoutSpeed": "STANDARD",
+      "status": "Active"
+    }
+  ],
+  "legalEntity": "Business",
+  "systemUpToDateTime": "2021-08-11T12:50:48+02:00",
+  "verification": {
+    "accountHolder": {
+      "checks": [
+        {
+          "type": "COMPANY_VERIFICATION",
+          "status": "PASSED",
+          "summary": {}
+        }
+      ]
+    },
+    "ultimateParentCompany": [
+      {
+        "checks": [
+          {
+            "type": "COMPANY_VERIFICATION",
+            "status": "PASSED",
+            "summary": {}
+          }
+        ],
+        "ultimateParentCompanyCode": "25aee067-3560-4e16-83d6-0b6aa96e7e85"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Used to supply parent company information.

**Description**
Add the missing `listedUltimateParentCompany` field, see also https://docs.adyen.com/api-explorer/#/Account/v6/post/createAccountHolder__reqParam_accountHolderDetails-businessDetails-listedUltimateParentCompany.
Also add it in the KYC verification result (https://docs.adyen.com/api-explorer/#/Account/v6/post/createAccountHolder__resParam_verification-ultimateParentCompany).

**Tested scenarios**
- Manual request with populated `listedUltimateParentCompany`, and verified that it arrives correctly at Adyen (and that the response can be parsed).
- JUnit test for checking that the JSON is parsed correctly into the model.

**Fixed issue**: N/A.
