### PR TITLE
add props 'showPages' and 'collectInformation' to GetOnboardingUrlRequest

### DIFF
--- a/src/main/java/com/adyen/model/hop/GetOnboardingUrlRequest.java
+++ b/src/main/java/com/adyen/model/hop/GetOnboardingUrlRequest.java
@@ -14,7 +14,7 @@
  *
  * Adyen Java API Library
  *
- * Copyright (c) 2020 Adyen B.V.
+ * Copyright (c) 2021 Adyen B.V.
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  */
@@ -45,10 +45,11 @@ public class GetOnboardingUrlRequest {
     @SerializedName("shopperLocale")
     private String shopperLocale = null;
 
-    public GetOnboardingUrlRequest accountHolderCode(String accountHolderCode) {
-        this.accountHolderCode = accountHolderCode;
-        return this;
-    }
+    @SerializedName("showPages")
+    private OnboardingShowPages showPages = null;
+
+    @SerializedName("collectInformation")
+    private OnboardingCollectInformation collectInformation = null;
 
     /**
      * The account holder code you provided when you created the account holder.
@@ -63,8 +64,8 @@ public class GetOnboardingUrlRequest {
         this.accountHolderCode = accountHolderCode;
     }
 
-    public GetOnboardingUrlRequest editMode(Boolean editMode) {
-        this.editMode = editMode;
+    public GetOnboardingUrlRequest accountHolderCode(String accountHolderCode) {
+        this.accountHolderCode = accountHolderCode;
         return this;
     }
 
@@ -81,8 +82,8 @@ public class GetOnboardingUrlRequest {
         this.editMode = editMode;
     }
 
-    public GetOnboardingUrlRequest platformName(String platformName) {
-        this.platformName = platformName;
+    public GetOnboardingUrlRequest editMode(Boolean editMode) {
+        this.editMode = editMode;
         return this;
     }
 
@@ -99,8 +100,8 @@ public class GetOnboardingUrlRequest {
         this.platformName = platformName;
     }
 
-    public GetOnboardingUrlRequest returnUrl(String returnUrl) {
-        this.returnUrl = returnUrl;
+    public GetOnboardingUrlRequest platformName(String platformName) {
+        this.platformName = platformName;
         return this;
     }
 
@@ -117,6 +118,11 @@ public class GetOnboardingUrlRequest {
         this.returnUrl = returnUrl;
     }
 
+    public GetOnboardingUrlRequest returnUrl(String returnUrl) {
+        this.returnUrl = returnUrl;
+        return this;
+    }
+
     /**
      * The language to be used in the page, specified by a combination of a language and country code. For example, **pt-BR**. \n\nIf not specified in the request or if the language is not supported, the page uses the browser language. If the browser language is not supported, the page uses **en-US** by default.\n\nFor a list supported languages, refer to [Change the page language](https://docs.adyen.com/platforms/onboarding-and-verification/hosted-onboarding-page#change-page-language).
      *
@@ -128,6 +134,47 @@ public class GetOnboardingUrlRequest {
 
     public void setShopperLocale(String shopperLocale) {
         this.shopperLocale = shopperLocale;
+    }
+
+    public GetOnboardingUrlRequest shopperLocale(String shopperLocale) {
+        this.shopperLocale = shopperLocale;
+        return this;
+    }
+
+    /**
+     * What pages should be shown on the hosted onbarding page
+     *
+     * @return
+     */
+    public OnboardingShowPages getShowPages() {
+        return showPages;
+    }
+
+    public void setShowPages(OnboardingShowPages showPages) {
+        this.showPages = showPages;
+    }
+
+    public GetOnboardingUrlRequest showPages(OnboardingShowPages showPages) {
+        this.showPages = showPages;
+        return this;
+    }
+
+    /**
+     * What information should be collected on the hosted onboarding page
+     *
+     * @return
+     */
+    public OnboardingCollectInformation getCollectInformation() {
+        return collectInformation;
+    }
+
+    public void setCollectInformation(OnboardingCollectInformation collectInformation) {
+        this.collectInformation = collectInformation;
+    }
+
+    public GetOnboardingUrlRequest collectInformation(OnboardingCollectInformation collectInformation) {
+        this.collectInformation = collectInformation;
+        return this;
     }
 
     @Override
@@ -143,12 +190,14 @@ public class GetOnboardingUrlRequest {
                 Objects.equals(this.editMode, getOnboardingUrlRequest.editMode) &&
                 Objects.equals(this.platformName, getOnboardingUrlRequest.platformName) &&
                 Objects.equals(this.returnUrl, getOnboardingUrlRequest.returnUrl) &&
-                Objects.equals(this.shopperLocale, getOnboardingUrlRequest.shopperLocale);
+                Objects.equals(this.shopperLocale, getOnboardingUrlRequest.shopperLocale) &&
+                Objects.equals(this.showPages, getOnboardingUrlRequest.showPages) &&
+                Objects.equals(this.collectInformation, getOnboardingUrlRequest.collectInformation);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountHolderCode, editMode, platformName, returnUrl, shopperLocale);
+        return Objects.hash(accountHolderCode, editMode, platformName, returnUrl, shopperLocale, showPages, collectInformation);
     }
 
 
@@ -162,6 +211,8 @@ public class GetOnboardingUrlRequest {
         sb.append("    platformName: ").append(toIndentedString(platformName)).append("\n");
         sb.append("    returnUrl: ").append(toIndentedString(returnUrl)).append("\n");
         sb.append("    shopperLocale: ").append(toIndentedString(shopperLocale)).append("\n");
+        sb.append("    showPages: ").append(toIndentedString(showPages)).append("\n");
+        sb.append("    collectInformation: ").append(toIndentedString(collectInformation)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/src/main/java/com/adyen/model/hop/OnboardingCollectInformation.java
+++ b/src/main/java/com/adyen/model/hop/OnboardingCollectInformation.java
@@ -1,0 +1,160 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Java API Library
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+package com.adyen.model.hop;
+
+import java.util.Objects;
+
+import com.google.gson.annotations.SerializedName;
+
+public class OnboardingCollectInformation {
+
+    @SerializedName("individualDetails")
+    private Boolean individualDetails = null;
+
+    @SerializedName("businessDetails")
+    private Boolean businessDetails = null;
+
+    @SerializedName("bankDetails")
+    private Boolean bankDetails = null;
+
+    @SerializedName("legalArrangementDetails")
+    private Boolean legalArrangementDetails = null;
+
+    @SerializedName("pciQuestionnaire")
+    private Boolean pciQuestionnaire = null;
+
+    @SerializedName("shareholderDetails")
+    private Boolean shareholderDetails = null;
+
+    public Boolean getIndividualDetails() {
+        return individualDetails;
+    }
+
+    public void setIndividualDetails(Boolean individualDetails) {
+        this.individualDetails = individualDetails;
+    }
+
+    public OnboardingCollectInformation individualDetails(Boolean individualDetails) {
+        this.individualDetails = individualDetails;
+        return this;
+    }
+
+    public Boolean getBusinessDetails() {
+        return businessDetails;
+    }
+
+    public void setBusinessDetails(Boolean businessDetails) {
+        this.businessDetails = businessDetails;
+    }
+
+    public OnboardingCollectInformation businessDetails(Boolean businessDetails) {
+        this.businessDetails = businessDetails;
+        return this;
+    }
+
+    public Boolean getBankDetails() {
+        return bankDetails;
+    }
+
+    public void setBankDetails(Boolean bankDetails) {
+        this.bankDetails = bankDetails;
+    }
+
+    public OnboardingCollectInformation bankDetails(Boolean bankDetails) {
+        this.bankDetails = bankDetails;
+        return this;
+    }
+
+    public Boolean getLegalArrangementDetails() {
+        return legalArrangementDetails;
+    }
+
+    public void setLegalArrangementDetails(Boolean legalArrangementDetails) {
+        this.legalArrangementDetails = legalArrangementDetails;
+    }
+
+    public OnboardingCollectInformation legalArrangementDetails(Boolean legalArrangementDetails) {
+        this.legalArrangementDetails = legalArrangementDetails;
+        return this;
+    }
+
+    public Boolean getPciQuestionnaire() {
+        return pciQuestionnaire;
+    }
+
+    public void setPciQuestionnaire(Boolean pciQuestionnaire) {
+        this.pciQuestionnaire = pciQuestionnaire;
+    }
+
+    public OnboardingCollectInformation pciQuestionnaire(Boolean pciQuestionnaire) {
+        this.pciQuestionnaire = pciQuestionnaire;
+        return this;
+    }
+
+    public Boolean getShareholderDetails() {
+        return shareholderDetails;
+    }
+
+    public void setShareholderDetails(Boolean shareholderDetails) {
+        this.shareholderDetails = shareholderDetails;
+    }
+
+    public OnboardingCollectInformation shareholderDetails(Boolean shareholderDetails) {
+        this.shareholderDetails = shareholderDetails;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OnboardingCollectInformation that = (OnboardingCollectInformation) o;
+        return Objects.equals(individualDetails, that.individualDetails) &&
+            Objects.equals(businessDetails, that.businessDetails) &&
+            Objects.equals(bankDetails, that.bankDetails) &&
+            Objects.equals(legalArrangementDetails, that.legalArrangementDetails) &&
+            Objects.equals(pciQuestionnaire, that.pciQuestionnaire) &&
+            Objects.equals(shareholderDetails, that.shareholderDetails);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(individualDetails, businessDetails, bankDetails, legalArrangementDetails, pciQuestionnaire, shareholderDetails);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("OnboardingCollectInformation{");
+        sb.append("individualDetails=").append(individualDetails);
+        sb.append(", businessDetails=").append(businessDetails);
+        sb.append(", bankDetails=").append(bankDetails);
+        sb.append(", legalArrangementDetails=").append(legalArrangementDetails);
+        sb.append(", pciQuestionnaire=").append(pciQuestionnaire);
+        sb.append(", shareholderDetails=").append(shareholderDetails);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/adyen/model/hop/OnboardingShowPages.java
+++ b/src/main/java/com/adyen/model/hop/OnboardingShowPages.java
@@ -1,0 +1,197 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Java API Library
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+package com.adyen.model.hop;
+
+import java.util.Objects;
+
+import com.google.gson.annotations.SerializedName;
+
+public class OnboardingShowPages {
+
+    @SerializedName("welcomePage")
+    private Boolean welcomePage = null;
+
+    @SerializedName("homePage")
+    private Boolean homePage = null;
+
+    @SerializedName("individualDetailsSummaryPage")
+    private Boolean individualDetailsSummaryPage = null;
+
+    @SerializedName("businessDetailsSummaryPage")
+    private Boolean businessDetailsSummaryPage = null;
+
+    @SerializedName("bankDetailsSummaryPage")
+    private Boolean bankDetailsSummaryPage = null;
+
+    @SerializedName("shareholderDetailsSummaryPage")
+    private Boolean shareholderDetailsSummaryPage = null;
+
+    @SerializedName("bankVerificationOptionsPage")
+    private Boolean bankVerificationOptionsPage = null;
+
+    @SerializedName("identityDocumentPage")
+    private Boolean identityDocumentPage = null;
+
+    public OnboardingShowPages bankDetailsSummaryPage(Boolean bankDetailsSummaryPage) {
+        this.bankDetailsSummaryPage = bankDetailsSummaryPage;
+        return this;
+    }
+
+    public OnboardingShowPages shareholderDetailsSummaryPage(Boolean shareholderDetailsSummaryPage) {
+        this.shareholderDetailsSummaryPage = shareholderDetailsSummaryPage;
+        return this;
+    }
+
+    public OnboardingShowPages bankVerificationOptionsPage(Boolean bankVerificationOptionsPage) {
+        this.bankVerificationOptionsPage = bankVerificationOptionsPage;
+        return this;
+    }
+
+    public OnboardingShowPages identityDocumentPage(Boolean identityDocumentPage) {
+        this.identityDocumentPage = identityDocumentPage;
+        return this;
+    }
+
+    public Boolean getWelcomePage() {
+        return welcomePage;
+    }
+
+    public void setWelcomePage(Boolean welcomePage) {
+        this.welcomePage = welcomePage;
+    }
+
+    public OnboardingShowPages welcomePage(Boolean welcomePage) {
+        this.welcomePage = welcomePage;
+        return this;
+    }
+
+    public Boolean getHomePage() {
+        return homePage;
+    }
+
+    public void setHomePage(Boolean homePage) {
+        this.homePage = homePage;
+    }
+
+    public OnboardingShowPages homePage(Boolean homePage) {
+        this.homePage = homePage;
+        return this;
+    }
+
+    public Boolean getIndividualDetailsSummaryPage() {
+        return individualDetailsSummaryPage;
+    }
+
+    public void setIndividualDetailsSummaryPage(Boolean individualDetailsSummaryPage) {
+        this.individualDetailsSummaryPage = individualDetailsSummaryPage;
+    }
+
+    public OnboardingShowPages individualDetailsSummaryPage(Boolean individualDetailsSummaryPage) {
+        this.individualDetailsSummaryPage = individualDetailsSummaryPage;
+        return this;
+    }
+
+    public Boolean getBusinessDetailsSummaryPage() {
+        return businessDetailsSummaryPage;
+    }
+
+    public void setBusinessDetailsSummaryPage(Boolean businessDetailsSummaryPage) {
+        this.businessDetailsSummaryPage = businessDetailsSummaryPage;
+    }
+
+    public OnboardingShowPages businessDetailsSummaryPage(Boolean businessDetailsSummaryPage) {
+        this.businessDetailsSummaryPage = businessDetailsSummaryPage;
+        return this;
+    }
+
+    public Boolean getBankDetailsSummaryPage() {
+        return bankDetailsSummaryPage;
+    }
+
+    public void setBankDetailsSummaryPage(Boolean bankDetailsSummaryPage) {
+        this.bankDetailsSummaryPage = bankDetailsSummaryPage;
+    }
+
+    public Boolean getShareholderDetailsSummaryPage() {
+        return shareholderDetailsSummaryPage;
+    }
+
+    public void setShareholderDetailsSummaryPage(Boolean shareholderDetailsSummaryPage) {
+        this.shareholderDetailsSummaryPage = shareholderDetailsSummaryPage;
+    }
+
+    public Boolean getBankVerificationOptionsPage() {
+        return bankVerificationOptionsPage;
+    }
+
+    public void setBankVerificationOptionsPage(Boolean bankVerificationOptionsPage) {
+        this.bankVerificationOptionsPage = bankVerificationOptionsPage;
+    }
+
+    public Boolean getIdentityDocumentPage() {
+        return identityDocumentPage;
+    }
+
+    public void setIdentityDocumentPage(Boolean identityDocumentPage) {
+        this.identityDocumentPage = identityDocumentPage;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OnboardingShowPages that = (OnboardingShowPages) o;
+        return Objects.equals(welcomePage, that.welcomePage) &&
+            Objects.equals(homePage, that.homePage) &&
+            Objects.equals(individualDetailsSummaryPage, that.individualDetailsSummaryPage) &&
+            Objects.equals(businessDetailsSummaryPage, that.businessDetailsSummaryPage) &&
+            Objects.equals(bankDetailsSummaryPage, that.bankDetailsSummaryPage) &&
+            Objects.equals(shareholderDetailsSummaryPage, that.shareholderDetailsSummaryPage) &&
+            Objects.equals(bankVerificationOptionsPage, that.bankVerificationOptionsPage) &&
+            Objects.equals(identityDocumentPage, that.identityDocumentPage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(welcomePage, homePage, individualDetailsSummaryPage, businessDetailsSummaryPage, bankDetailsSummaryPage, shareholderDetailsSummaryPage, bankVerificationOptionsPage, identityDocumentPage);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("class OnboardingShowPages{");
+        sb.append("welcomePage=").append(welcomePage);
+        sb.append(", homePage=").append(homePage);
+        sb.append(", individualDetailsSummaryPage=").append(individualDetailsSummaryPage);
+        sb.append(", businessDetailsSummaryPage=").append(businessDetailsSummaryPage);
+        sb.append(", bankDetailsSummaryPage=").append(bankDetailsSummaryPage);
+        sb.append(", shareholderDetailsSummaryPage=").append(shareholderDetailsSummaryPage);
+        sb.append(", bankVerificationOptionsPage=").append(bankVerificationOptionsPage);
+        sb.append(", identityDocumentPage=").append(identityDocumentPage);
+        sb.append('}');
+        return sb.toString();
+    }
+
+}


### PR DESCRIPTION
**Description**
Interacting with a Adyen business developer Robert Ruppi, we (FINNnoECOM) got forwarded extra config flags "showPages" and "collectInformation" to send to the create hosted onbarding page url endpoint, to tailor what is shown and what is collected. Currently we call the API directly without using the SDK, but it would be nice to get this into the SDK as well.

**Tested scenarios**
I built the SDK as 17.0.1-SNAPSHOT and included it in our repo. and tested it towards the test environment where I successfully got back an hosted onboarding page url. Not tested towards the live environment as we don't have set up that environment yet. (Working on it though).