### PR TITLE
[PW-5474] - Add the requestChallengeAsMandate ENUM

### DIFF
--- a/src/main/java/com/adyen/model/ThreeDS2RequestData.java
+++ b/src/main/java/com/adyen/model/ThreeDS2RequestData.java
@@ -90,6 +90,9 @@ public class ThreeDS2RequestData {
         }
     }
 
+    /**
+     * @deprecated As of Checkout/Payments API version 68, this field is not used anymore.
+     */
     @Deprecated
     @SerializedName("challengeIndicator")
     private ChallengeIndicatorEnum challengeIndicator = null;
@@ -216,15 +219,27 @@ public class ThreeDS2RequestData {
         this.authenticationOnly = authenticationOnly;
     }
 
+    /**
+     * @deprecated As of Checkout/Payments API version 68, this field is not used anymore.
+     */
+    @Deprecated
     public ThreeDS2RequestData challengeIndicator(ChallengeIndicatorEnum challengeIndicator) {
         this.challengeIndicator = challengeIndicator;
         return this;
     }
 
+    /**
+     * @deprecated As of Checkout/Payments API version 68, this field is not used anymore.
+     */
+    @Deprecated
     public ChallengeIndicatorEnum getChallengeIndicator() {
         return challengeIndicator;
     }
 
+    /**
+     * @deprecated As of Checkout/Payments API version 68, this field is not used anymore.
+     */
+    @Deprecated
     public void setChallengeIndicator(ChallengeIndicatorEnum challengeIndicator) {
         this.challengeIndicator = challengeIndicator;
     }


### PR DESCRIPTION
**Description**
Based on these checkout [docs](https://docs.adyen.com/api-explorer/#/CheckoutService/v64/post/payments__reqParam_threeDS2RequestData-challengeIndicator) `challengeIndicator` can be set as `requestChallengeAsMandate`. Deprecated tags should also be added on this field, since it was removed in **v68**.

Additionally, add the field that will replace it in v68: `threeDSRequestorChallengeInd`
