### PR TITLE
Hmac validator null-safe check

### DIFF
--- a/src/main/java/com/adyen/util/HMACValidator.java
+++ b/src/main/java/com/adyen/util/HMACValidator.java
@@ -79,7 +79,9 @@ public class HMACValidator {
             throw new IllegalArgumentException("Missing NotificationRequestItem.");
         }
 
-        if (notificationRequestItem.getAdditionalData() == null || notificationRequestItem.getAdditionalData().get(HMAC_SIGNATURE).isEmpty()) {
+        if (notificationRequestItem.getAdditionalData() == null
+                || notificationRequestItem.getAdditionalData().get(HMAC_SIGNATURE) == null
+                || notificationRequestItem.getAdditionalData().get(HMAC_SIGNATURE).isEmpty()) {
             throw new IllegalArgumentException("Missing " + HMAC_SIGNATURE);
         }
         final byte[] merchantSign = (notificationRequestItem.getAdditionalData().get(HMAC_SIGNATURE)).getBytes(StandardCharsets.UTF_8);

--- a/src/test/java/com/adyen/util/HMACValidatorTest.java
+++ b/src/test/java/com/adyen/util/HMACValidatorTest.java
@@ -21,12 +21,10 @@
 
 package com.adyen.util;
 
+import java.security.SignatureException;
+import org.junit.Test;
 import com.adyen.model.notification.NotificationRequestItem;
 import com.google.gson.Gson;
-import org.junit.Test;
-
-import java.security.SignatureException;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -57,6 +55,59 @@ public class HMACValidatorTest {
         NotificationRequestItem notificationRequest = new Gson().fromJson(notificationJson, NotificationRequestItem.class);
         boolean result = new HMACValidator().validateHMAC(notificationRequest, HMAC_KEY);
         assertTrue(result);
+    }
+
+    @Test
+    public void testValidateHMACNullHmacSignature() throws SignatureException {
+        String notificationJson = "{\n"
+                + "    \"additionalData\": {\n"
+                + "    },\n"
+                + "    \"amount\": {\n"
+                + "        \"currency\": \"EUR\",\n"
+                + "        \"value\": \"0\"\n"
+                + "    },\n"
+                + "    \"eventCode\": \"REPORT_AVAILABLE\",\n"
+                + "    \"eventDate\": \"2019-11-20T14:35:36+01:00\",\n"
+                + "    \"merchantAccountCode\": \"Magento2Rik\",\n"
+                + "    \"merchantReference\": \"testMerchantRef1\",\n"
+                + "    \"pspReference\": \"test_REPORT_AVAILABLE\",\n"
+                + "    \"reason\": \"will contain the url to the report\",\n"
+                + "    \"success\": \"true\"\n"
+                + "}";
+        try {
+            NotificationRequestItem notificationRequest = new Gson().fromJson(notificationJson, NotificationRequestItem.class);
+            boolean result = new HMACValidator().validateHMAC(notificationRequest, HMAC_KEY);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Missing hmacSignature", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testValidateHMACEmptyHmacSignature() throws SignatureException {
+        String notificationJson = "{\n"
+                + "    \"additionalData\": {\n"
+                + "        \"hmacSignature\": \"\"\n"
+                + "    },\n"
+                + "    \"amount\": {\n"
+                + "        \"currency\": \"EUR\",\n"
+                + "        \"value\": \"0\"\n"
+                + "    },\n"
+                + "    \"eventCode\": \"REPORT_AVAILABLE\",\n"
+                + "    \"eventDate\": \"2019-11-20T14:35:36+01:00\",\n"
+                + "    \"merchantAccountCode\": \"Magento2Rik\",\n"
+                + "    \"merchantReference\": \"testMerchantRef1\",\n"
+                + "    \"pspReference\": \"test_REPORT_AVAILABLE\",\n"
+                + "    \"reason\": \"will contain the url to the report\",\n"
+                + "    \"success\": \"true\"\n"
+                + "}";
+        try {
+            NotificationRequestItem notificationRequest = new Gson().fromJson(notificationJson, NotificationRequestItem.class);
+            boolean result = new HMACValidator().validateHMAC(notificationRequest, HMAC_KEY);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Missing hmacSignature", e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Hmac validator is not null safe, because notificationRequestItem.getAdditionalData().get(HMAC_SIGNATURE) returns null if addtionalData does not contain a key "hmacSignature" (or a possible null value for key "hmacSignature").
There is an extra null-safe check implented in this PR
 
**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
Fixes #623