### PR TITLE
Add support for encoded SSC

### DIFF
--- a/src/main/java/com/adyen/model/nexo/ContentInformation.java
+++ b/src/main/java/com/adyen/model/nexo/ContentInformation.java
@@ -1,5 +1,8 @@
 package com.adyen.model.nexo;
 
+import com.adyen.serializer.SSCSerializer;
+import com.google.gson.annotations.JsonAdapter;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -72,7 +75,11 @@ public class ContentInformation {
      */
     @XmlElement(name = "ContentType", required = true)
     protected ContentType contentType;
-
+    
+    @XmlElement(name = "ssc")
+    @JsonAdapter(SSCSerializer.class)
+    protected SSC ssc;
+    
     /**
      * Gets the value of the envelopedData property.
      *
@@ -179,6 +186,24 @@ public class ContentInformation {
      */
     public void setContentType(ContentType value) {
         this.contentType = value;
+    }
+
+    /**
+     * Gets the value of the ssc property.
+     *
+     * @return possible      object is     {@link SSC }
+     */
+    public SSC getSsc() {
+        return ssc;
+    }
+
+    /**
+     * Sets the value of the ssc property.
+     *
+     * @param value allowed object is     {@link SSC }
+     */
+    public void setSsc(SSC value) {
+        this.ssc = value;
     }
 
 }

--- a/src/main/java/com/adyen/model/nexo/PaymentInstrumentData.java
+++ b/src/main/java/com/adyen/model/nexo/PaymentInstrumentData.java
@@ -1,11 +1,10 @@
 package com.adyen.model.nexo;
 
+import com.adyen.serializer.SSCSerializer;
+import com.google.gson.annotations.JsonAdapter;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.*;
 
 
 /**
@@ -72,6 +71,10 @@ public class PaymentInstrumentData {
      */
     @XmlElement(name = "ProtectedCardData")
     protected ContentInformation protectedCardData;
+
+    @XmlAttribute(name = "ProtectedCardData")
+    @JsonAdapter(SSCSerializer.class)
+    protected SSC protectedSSCData;
 
     /**
      * Gets the value of the cardData property.
@@ -170,6 +173,14 @@ public class PaymentInstrumentData {
      */
     public ContentInformation getProtectedCardData() {
         return protectedCardData;
+    }
+    
+    public SSC getProtectedSSCData() {
+        return protectedSSCData;
+    }
+    
+    public void setProtectedSSCData(SSC value) {
+        this.protectedSSCData = value;
     }
 
     /**

--- a/src/main/java/com/adyen/model/nexo/PaymentInstrumentData.java
+++ b/src/main/java/com/adyen/model/nexo/PaymentInstrumentData.java
@@ -1,10 +1,11 @@
 package com.adyen.model.nexo;
 
-import com.adyen.serializer.SSCSerializer;
-import com.google.gson.annotations.JsonAdapter;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 
 
 /**
@@ -71,10 +72,6 @@ public class PaymentInstrumentData {
      */
     @XmlElement(name = "ProtectedCardData")
     protected ContentInformation protectedCardData;
-
-    @XmlAttribute(name = "ProtectedSSCData")
-    @JsonAdapter(SSCSerializer.class)
-    protected SSC protectedSSCData;
 
     /**
      * Gets the value of the cardData property.
@@ -173,14 +170,6 @@ public class PaymentInstrumentData {
      */
     public ContentInformation getProtectedCardData() {
         return protectedCardData;
-    }
-    
-    public SSC getProtectedSSCData() {
-        return protectedSSCData;
-    }
-    
-    public void setProtectedSSCData(SSC value) {
-        this.protectedSSCData = value;
     }
 
     /**

--- a/src/main/java/com/adyen/model/nexo/PaymentInstrumentData.java
+++ b/src/main/java/com/adyen/model/nexo/PaymentInstrumentData.java
@@ -72,7 +72,7 @@ public class PaymentInstrumentData {
     @XmlElement(name = "ProtectedCardData")
     protected ContentInformation protectedCardData;
 
-    @XmlAttribute(name = "ProtectedCardData")
+    @XmlAttribute(name = "ProtectedSSCData")
     @JsonAdapter(SSCSerializer.class)
     protected SSC protectedSSCData;
 

--- a/src/main/java/com/adyen/model/nexo/SSC.java
+++ b/src/main/java/com/adyen/model/nexo/SSC.java
@@ -1,0 +1,64 @@
+package com.adyen.model.nexo;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.codec.binary.Base64;
+
+import java.util.Objects;
+
+
+public class SSC {
+
+    protected String ssc;
+
+    private static final Gson PRETTY_PRINT_GSON = new GsonBuilder().setPrettyPrinting().create();
+    
+    public String getSsc() {
+        return ssc;
+    }
+    
+    public void setSsc(String ssc) {
+        this.ssc = ssc;
+    }
+
+    public static Gson getPrettyPrintGson() {
+        return PRETTY_PRINT_GSON;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SSC that = (SSC) o;
+        return Objects.equals(ssc, that.ssc);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ssc);
+    }
+
+    @Override
+    public String toString() {
+        return "ProtectedCardData{" +
+                "ssc=" + ssc +
+                '}';
+    }
+    
+
+    
+    public String toBase64() {
+        String json = PRETTY_PRINT_GSON.toJson(this);
+        return new String(Base64.encodeBase64(json.getBytes()));
+    }
+
+    public SSC fromBase64(byte[] jsonResponse) {
+      return PRETTY_PRINT_GSON.fromJson(new String(Base64.decodeBase64(jsonResponse)), SSC.class);
+    }
+ 
+}
+

--- a/src/main/java/com/adyen/serializer/SSCSerializer.java
+++ b/src/main/java/com/adyen/serializer/SSCSerializer.java
@@ -1,0 +1,19 @@
+package com.adyen.serializer;
+
+import com.adyen.model.nexo.SSC;
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+
+public class SSCSerializer implements JsonSerializer<SSC>, JsonDeserializer<SSC> {
+
+    public JsonElement serialize(SSC sscSerializeObject, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(sscSerializeObject.toBase64());
+    }
+
+    public SSC deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        SSC sscDeserializeObject = new SSC();
+        return sscDeserializeObject.fromBase64(json.getAsString().getBytes());
+    }
+}
+


### PR DESCRIPTION
**Description**
ProtectedCardData does not work to add a SSC. Support for a direct encoded string is required for Secondary Security Code on the Adyen Terminal. This change will add encode the SSC taken from the Card Details, and allow it to be set in the PaymentInstrumentData object. 
