### PR TITLE
OnLinePIN should be without capital L

### DIFF
--- a/src/main/java/com/adyen/model/nexo/AuthenticationMethodType.java
+++ b/src/main/java/com/adyen/model/nexo/AuthenticationMethodType.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
  *     &lt;enumeration value="ManualVerification"/&gt;
  *     &lt;enumeration value="MerchantAuthentication"/&gt;
  *     &lt;enumeration value="OfflinePIN"/&gt;
- *     &lt;enumeration value="OnLinePIN"/&gt;
+ *     &lt;enumeration value="OnlinePIN"/&gt;
  *     &lt;enumeration value="PaperSignature"/&gt;
  *     &lt;enumeration value="SecuredChannel"/&gt;
  *     &lt;enumeration value="SecureCertificate"/&gt;
@@ -67,7 +67,7 @@ public enum AuthenticationMethodType {
     /**
      * On-line PIN authentication (Personal Identification Number).
      */
-    @XmlEnumValue("OnLinePIN")
+    @XmlEnumValue("OnlinePIN")
     @Schema(description = "On-line PIN authentication (Personal Identification Number).")
     ON_LINE_PIN("OnLinePIN", "OnlinePIN"),
 


### PR DESCRIPTION
https://docs.adyen.com/point-of-sale/terminal-api-reference#comadyennexoauthenticationmethod

Docs state that OnlinePIN in nexo.authenticationMethod should indeed without L just like the merchant mentioned he received in his respons. Correctly changing XMLEnumValue should not impact current merchant implementations.

**Fixed issue**:  #758 
