### PR TITLE
Random is replaced with SecureRandom at nonce IV block generation

### DIFF
--- a/src/main/java/com/adyen/terminal/security/NexoCrypto.java
+++ b/src/main/java/com/adyen/terminal/security/NexoCrypto.java
@@ -41,11 +41,13 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Random;
+import java.security.SecureRandom;
 
 import static com.adyen.model.terminal.security.NexoDerivedKey.NEXO_IV_LENGTH;
 
 public class NexoCrypto {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public SaleToPOISecuredMessage encrypt(
             String saleToPoiMessageJson, MessageHeader messageHeader, SecurityKey securityKey) throws Exception {
@@ -149,7 +151,7 @@ public class NexoCrypto {
      */
     private byte[] generateRandomIvNonce() {
         byte[] ivNonce = new byte[NEXO_IV_LENGTH];
-        new Random().nextBytes(ivNonce);
+        SECURE_RANDOM.nextBytes(ivNonce);
         return ivNonce;
     }
 }


### PR DESCRIPTION
**Description**
Random replacement with singleton SecureRandom

**Tested scenarios**
Run UTs

**Fixed issue**:  #775 
