### PR TITLE
Missing NonProfit CreateAccountHolderRequest.LegalEntityEnum option

### DIFF
--- a/src/main/java/com/adyen/model/marketpay/CreateAccountHolderRequest.java
+++ b/src/main/java/com/adyen/model/marketpay/CreateAccountHolderRequest.java
@@ -58,7 +58,10 @@ public class CreateAccountHolderRequest {
         BUSINESS("Business"),
 
         @SerializedName("Individual")
-        INDIVIDUAL("Individual");
+        INDIVIDUAL("Individual"),
+
+        @SerializedName("NonProfit")
+        NONPROFIT("NonProfit");
 
         @JsonValue
         private final String value;


### PR DESCRIPTION
**Description**
According to https://docs.adyen.com/api-explorer/#/Account/v6/post/createAccountHolder__reqParam_legalEntity there is NonProfit option missing in current enum implementation for CreateAccountHolder request.