### PR TITLE
[PW-7093] authorise/authorise3D can set ApplicationInfo

### DIFF
--- a/src/main/java/com/adyen/model/AbstractPaymentRequest.java
+++ b/src/main/java/com/adyen/model/AbstractPaymentRequest.java
@@ -194,7 +194,7 @@ public abstract class AbstractPaymentRequest<T extends AbstractPaymentRequest<T>
     private Map<String, String> metadata = null;
 
     @SerializedName("applicationInfo")
-    private final ApplicationInfo applicationInfo;
+    private ApplicationInfo applicationInfo;
 
     @SerializedName("enableRealTimeUpdate")
     private Boolean enableRealTimeUpdate = null;
@@ -814,6 +814,10 @@ public abstract class AbstractPaymentRequest<T extends AbstractPaymentRequest<T>
 
     public ApplicationInfo getApplicationInfo() {
         return applicationInfo;
+    }
+
+    public void setApplicationInfo(ApplicationInfo applicationInfo) {
+        this.applicationInfo = applicationInfo;
     }
 
     /**

--- a/src/test/java/com/adyen/PaymentTest.java
+++ b/src/test/java/com/adyen/PaymentTest.java
@@ -36,6 +36,8 @@ import com.adyen.model.PaymentResult;
 import com.adyen.model.RequestOptions;
 import com.adyen.model.ThreeDS2ResultRequest;
 import com.adyen.model.ThreeDS2ResultResponse;
+import com.adyen.model.applicationinfo.ApplicationInfo;
+import com.adyen.model.applicationinfo.MerchantDevice;
 import com.adyen.service.Payment;
 import com.adyen.service.exception.ApiException;
 import org.junit.Test;
@@ -75,6 +77,13 @@ public class PaymentTest extends BaseTest {
         Payment payment = new Payment(client);
 
         PaymentRequest paymentRequest = createFullCardPaymentRequest();
+
+        MerchantDevice device = new MerchantDevice();
+        device.setOs("LINUX");
+
+        ApplicationInfo applicationInfo = new ApplicationInfo();
+        applicationInfo.setMerchantDevice(device);
+        paymentRequest.setApplicationInfo(applicationInfo);
 
         PaymentResult paymentResult = payment.authorise(paymentRequest);
 


### PR DESCRIPTION
**Description**
Needed to add a setter in AbstractPaymentRequest which extends the PaymentRequest/PaymentRequest3D class. 

**Tested scenarios**
Unit Test.

**Fixed issue**:  PW-7093 (issue from partner ChargeBee)
