### PR TITLE
Add no-args constructor to ErrorFieldTypeContainer so that it can be deserialized

### DIFF
--- a/src/main/java/com/adyen/model/marketpay/ErrorFieldTypeContainer.java
+++ b/src/main/java/com/adyen/model/marketpay/ErrorFieldTypeContainer.java
@@ -33,6 +33,8 @@ public class ErrorFieldTypeContainer {
     @JsonProperty("ErrorFieldType")
     private ErrorFieldType errorFieldType;
 
+    public ErrorFieldTypeContainer() {}
+
     public ErrorFieldTypeContainer(ErrorFieldType errorFieldType) {
         this.errorFieldType = errorFieldType;
     }

--- a/src/main/java/com/adyen/model/marketpay/ErrorFieldTypeContainer.java
+++ b/src/main/java/com/adyen/model/marketpay/ErrorFieldTypeContainer.java
@@ -33,7 +33,8 @@ public class ErrorFieldTypeContainer {
     @JsonProperty("ErrorFieldType")
     private ErrorFieldType errorFieldType;
 
-    public ErrorFieldTypeContainer() {}
+    public ErrorFieldTypeContainer() {
+    }
 
     public ErrorFieldTypeContainer(ErrorFieldType errorFieldType) {
         this.errorFieldType = errorFieldType;

--- a/src/main/java/com/adyen/model/marketpay/Message.java
+++ b/src/main/java/com/adyen/model/marketpay/Message.java
@@ -23,6 +23,8 @@ package com.adyen.model.marketpay;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Objects;
+
 public class Message {
     @SerializedName("code")
     private String code;
@@ -49,5 +51,22 @@ public class Message {
     @Override
     public String toString() {
         return "Message{" + "code='" + code + '\'' + ", text='" + text + '\'' + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Message message = (Message) o;
+        return Objects.equals(code, message.code) && Objects.equals(text, message.text);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, text);
     }
 }

--- a/src/main/java/com/adyen/model/marketpay/notification/PaymentFailureNotificationContent.java
+++ b/src/main/java/com/adyen/model/marketpay/notification/PaymentFailureNotificationContent.java
@@ -29,6 +29,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class PaymentFailureNotificationContent {
     @SerializedName("errorFields")
@@ -110,5 +111,30 @@ public class PaymentFailureNotificationContent {
     @Override
     public String toString() {
         return "PaymentFailureContent{" + "errorFieldTypeContainers=" + errorFieldTypeContainers + ", errorMessage=" + errorMessage + ", modificationMerchantReference=" + modificationMerchantReference + ", modificationPspReference=" + modificationPspReference + ", paymentMerchantReference=" + paymentMerchantReference + ", paymentPspReference=" + paymentPspReference + '}';
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PaymentFailureNotificationContent that = (PaymentFailureNotificationContent) o;
+        return Objects.equals(errorFieldTypeContainers, that.errorFieldTypeContainers) &&
+                Objects.equals(errorMessage, that.errorMessage) &&
+                Objects.equals(modificationMerchantReference, that.modificationMerchantReference) &&
+                Objects.equals(modificationPspReference, that.modificationPspReference) &&
+                Objects.equals(paymentMerchantReference, that.paymentMerchantReference) &&
+                Objects.equals(paymentPspReference, that.paymentPspReference);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(errorFieldTypeContainers,
+                errorMessage,
+                modificationMerchantReference,
+                modificationPspReference,
+                paymentMerchantReference,
+                paymentPspReference);
     }
 }

--- a/src/test/java/com/adyen/model/marketpay/notification/PaymentFailureNotificationTest.java
+++ b/src/test/java/com/adyen/model/marketpay/notification/PaymentFailureNotificationTest.java
@@ -1,0 +1,97 @@
+package com.adyen.model.marketpay.notification;
+
+import com.adyen.model.marketpay.ErrorFieldType;
+import com.adyen.model.marketpay.ErrorFieldTypeContainer;
+import com.adyen.model.marketpay.FieldType;
+import com.adyen.model.marketpay.Message;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+
+import static com.adyen.model.marketpay.FieldType.FieldNameEnum.FIRSTNAME;
+import static org.junit.Assert.assertEquals;
+
+public class PaymentFailureNotificationTest {
+
+    @Test
+    public void testPaymentFailureNotificationCanBeDeserialized() throws Exception {
+        String json = "{\n" +
+                "  \"eventType\":null,\n" +
+                "  \"content\":{\n" +
+                "    \"errorMessage\":{\n" +
+                "      \"code\":\"message-code\",\n" +
+                "      \"text\":\"message-text\"\n" +
+                "    },\n" +
+                "    \"modificationMerchantReference\":\"modification-merchant-reference\",\n" +
+                "    \"modificationPspReference\":\"modification-psp-reference\",\n" +
+                "    \"paymentMerchantReference\":\"payment-merchant-reference\",\n" +
+                "    \"paymentPspReference\":\"TSTPSPR0001\",\n" +
+                "    \"errorFieldList\":[\n" +
+                "      {\n" +
+                "        \"errorDescription\":\"error-description\",\n" +
+                "        \"errorCode\":3,\n" +
+                "        \"fieldType\":{\n" +
+                "          \"fieldName\":\"firstName\",\n" +
+                "          \"field\":\"field\",\n" +
+                "          \"shareholderCode\":\"shareholder-code\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"errorFields\":[\n" +
+                "      {\n" +
+                "        \"ErrorFieldType\":{\n" +
+                "          \"errorDescription\":\"error-description\",\n" +
+                "          \"errorCode\":3,\n" +
+                "          \"fieldType\":{\n" +
+                "            \"fieldName\":\"firstName\",\n" +
+                "            \"field\":\"field\",\n" +
+                "            \"shareholderCode\":\"shareholder-code\"\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"error\":{\n" +
+                "    \"errorCode\":\"error-code\",\n" +
+                "    \"message\":\"error-message\"\n" +
+                "  },\n" +
+                "  \"eventDate\":0,\n" +
+                "  \"executingUserKey\":\"executing-user-key\",\n" +
+                "  \"live\":true,\n" +
+                "  \"pspReference\":\"TSTPSPR0001\"\n" +
+                "}";
+
+        PaymentFailureNotification paymentFailureNotification = new ObjectMapper().reader().forType(PaymentFailureNotification.class).readValue(json);
+
+        String pspReference = "TSTPSPR0001";
+        PaymentFailureNotificationContent content = new PaymentFailureNotificationContent();
+        content.setPaymentPspReference(pspReference);
+        content.setPaymentMerchantReference("payment-merchant-reference");
+        content.setModificationPspReference("modification-psp-reference");
+        content.setModificationMerchantReference("modification-merchant-reference");
+        Message errorMessage = new Message();
+        errorMessage.setCode("message-code");
+        errorMessage.setText("message-text");
+        content.setErrorMessage(errorMessage);
+        content.setErrorFieldTypeContainers(
+                Collections.singletonList(
+                        new ErrorFieldTypeContainer(
+                                new ErrorFieldType()
+                                        .errorCode(3)
+                                        .fieldType(new FieldType().field("field").shareholderCode("shareholder-code").fieldName(FIRSTNAME))
+                                        .errorDescription("error-description"))));
+        assertEquals(paymentFailureNotification,
+                new PaymentFailureNotification()
+                        .error(new NotificationErrorContainer()
+                                .errorCode("error-code")
+                                .message("error-message"))
+                        .eventDate(Date.from(Instant.EPOCH))
+                        .executingUserKey("executing-user-key")
+                        .live(true)
+                        .pspReference(pspReference)
+                        .content(content));
+    }
+}


### PR DESCRIPTION
**Description**
- Added a default no-args constructor to `ErrorFieldTypeContainer`.
- Added equals and hashCode methods to `Message` and `PaymentFailureNotificationContent`.

I am a developer who integrates Adyen notification webhooks to our Spring application. We are having issues with the `PAYMENT_FAILURE` notification type.

Our Spring framework cannot deserialize the `PaymentFailureNotification` object received from Adyen. `PaymentFailureNotification.PaymentFailureNotificationContent.ErrorFieldTypeContainer` class doesn't have a default no-args constructor required by Jackson (utilized by Spring) to deserialize objects.

**Tested scenarios**
Jackson can deserialize `PaymentFailureNotification`.

---
Stacktrace:

```
org.springframework.http.converter.HttpMessageConversionException: Type definition error: [simple type, class com.adyen.model.marketpay.ErrorFieldTypeContainer]; nested exception is com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.adyen.model.marketpay.ErrorFieldTypeContainer` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
at [Source: (PushbackInputStream); line: 1, column: 173] (through reference chain: com.adyen.model.marketpay.notification.PaymentFailureNotification["content"]->com.adyen.model.marketpay.notification.PaymentFailureNotificationContent["errorFields"]->java.util.ArrayList[0])
at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.readJavaType(AbstractJackson2HttpMessageConverter.java:386) ~[spring-web-5.3.7.jar!/:5.3.7]
at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.read(AbstractJackson2HttpMessageConverter.java:342) ~[spring-web-5.3.7.jar!/:5.3.7]
at org.springframework.web.servlet.mvc.method.annotation.AbstractMessageConverterMethodArgumentResolver.readWithMessageConverters(AbstractMessageConverterMethodArgumentResolver.java:185) ~[spring-webmvc-5.3.7.jar!/:5.3.7]
at org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor.readWithMessageConverters(RequestResponseBodyMethodProcessor.java:158) ~[spring-webmvc-5.3.7.jar!/:5.3.7]
at org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor.resolveArgument(RequestResponseBodyMethodProcessor.java:131) ~[spring-webmvc-5.3.7.jar!/:5.3.7]
at org.springframework.web.method.support.HandlerMethodArgumentResolverComposite.resolveArgument(HandlerMethodArgumentResolverComposite.java:121) ~[spring-web-5.3.7.jar!/:5.3.7]
at org.springframework.web.method.support.InvocableHandlerMethod.getMethodArgumentValues(InvocableHandlerMethod.java:170) ~[spring-web-5.3.7.jar!/:5.3.7]
at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:137) ~[spring-web-5.3.7.jar!/:5.3.7]
at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:106) ~[spring-webmvc-5.3.7.jar!/:5.3.7]
...
```
---
Our controller implementation:

```java
@PostMapping("/paymentFailure")
public ResponseEntity<String> paymentFailure(@RequestBody PaymentFailureNotification notificationRequest) {
// Jackson fails to deserialize the PaymentFailureNotification
log.info("Received {}", notificationRequest.toString());
adyenNotificationConsumer.accept(notificationRequest);
return ResponseEntity.ok().body(ADYEN_ACCEPTED);
}
```
---
A unit test to reproduce the problem:

```java
@Test
void tmp() throws Exception {
var json = """
{"eventType":"PAYMENT_FAILURE","content":{"errorMessage":null,"modificationMerchantReference":null,"modificationPspReference":null,"paymentMerchantReference":null,"paymentPspReference":null,"errorFieldList":[{"errorDescription":null,"errorCode":null,"fieldType":{"fieldName":"firstName","field":"abc","shareholderCode":null}}],"errorFields":[{"ErrorFieldType":{"errorDescription":null,"errorCode":null,"fieldType":{"fieldName":"firstName","field":"abc","shareholderCode":null}}}]},"error":null,"eventDate":0,"executingUserKey":null,"live":true,"pspReference":"TSTPSPR0001"}
""";

PaymentFailureNotification paymentFailureNotification = new ObjectMapper().reader()
.forType(PaymentFailureNotification.class).readValue(json); // fails with InvalidDefinitionException
}
```
