### PR TITLE
PW-7204: Add AuthenticationNotRequired

### DIFF
--- a/src/main/java/com/adyen/model/PaymentResult.java
+++ b/src/main/java/com/adyen/model/PaymentResult.java
@@ -75,6 +75,8 @@ public class PaymentResult {
     public enum ResultCodeEnum {
         @SerializedName("AuthenticationFinished")
         AUTHENTICATIONFINISHED("AuthenticationFinished"),
+        @SerializedName("AuthenticationNotRequired")
+        AUTHENTICATIONNOTREQUIRED("AuthenticationNotRequired"),
         @SerializedName("Authorised")
         AUTHORISED("Authorised"),
         @SerializedName("Cancelled")

--- a/src/test/java/com/adyen/PaymentResultTest.java
+++ b/src/test/java/com/adyen/PaymentResultTest.java
@@ -4,6 +4,7 @@ import com.adyen.model.PaymentResult;
 import com.google.gson.Gson;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class PaymentResultTest extends BaseTest {
@@ -14,5 +15,13 @@ public class PaymentResultTest extends BaseTest {
         String response = "{\"resultCode\": \"AuthenticationFinished\"}";
         PaymentResult result = gson.fromJson(response, PaymentResult.class);
         assertNotNull(result.getResultCode());
+    }
+
+    @Test
+    public void TestAuthenticationNotRequiredResultCodeDeserialization() {
+        Gson gson = new Gson();
+        String response = "{\"resultCode\": \"AuthenticationNotRequired\"}";
+        PaymentResult result = gson.fromJson(response, PaymentResult.class);
+        assertEquals(result.getResultCode(), PaymentResult.ResultCodeEnum.AUTHENTICATIONNOTREQUIRED);
     }
 }


### PR DESCRIPTION
**Description**

The result code [AuthenticationNotRequired](https://docs.adyen.com/api-explorer-beta/Payment/52/post/authorise#responses-200-resultCode) was missing from the library. It's already documented and will be added to the specs soon.  