### PR TITLE
PW-7327: Serialise ByteArray into JSON String

### DIFF
--- a/src/main/java/com/adyen/model/ThreeDSecureData.java
+++ b/src/main/java/com/adyen/model/ThreeDSecureData.java
@@ -205,12 +205,14 @@ public class ThreeDSecureData {
     private String threeDSVersion = null;
 
     @SerializedName("tokenAuthenticationVerificationValue")
+    @JsonAdapter(ByteArrayToStringAdapter.class)
     private byte[] tokenAuthenticationVerificationValue = null;
 
     @SerializedName("transStatusReason")
     private String transStatusReason = null;
 
     @SerializedName("xid")
+    @JsonAdapter(ByteArrayToStringAdapter.class)
     private byte[] xid = null;
 
     public ThreeDSecureData authenticationResponse(AuthenticationResponseEnum authenticationResponse) {

--- a/src/main/java/com/adyen/model/ThreeDSecureData.java
+++ b/src/main/java/com/adyen/model/ThreeDSecureData.java
@@ -20,6 +20,7 @@
  */
 package com.adyen.model;
 
+import com.adyen.serializer.ByteArrayToStringAdapter;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
@@ -84,6 +85,7 @@ public class ThreeDSecureData {
     private AuthenticationResponseEnum authenticationResponse = null;
 
     @SerializedName("cavv")
+    @JsonAdapter(ByteArrayToStringAdapter.class)
     private byte[] cavv = null;
 
     @SerializedName("cavvAlgorithm")

--- a/src/test/java/com/adyen/PaymentTest.java
+++ b/src/test/java/com/adyen/PaymentTest.java
@@ -20,22 +20,13 @@
  */
 package com.adyen;
 
+import com.adyen.constants.ApiConstants;
 import com.adyen.constants.ApiConstants.AdditionalData;
 import com.adyen.constants.ApiConstants.RefusalReason;
 import com.adyen.httpclient.AdyenHttpClient;
+import com.adyen.httpclient.ClientInterface;
 import com.adyen.httpclient.HTTPClientException;
-import com.adyen.model.Address;
-import com.adyen.model.AuthenticationResultRequest;
-import com.adyen.model.AuthenticationResultResponse;
-import com.adyen.model.FraudCheckResult;
-import com.adyen.model.Name;
-import com.adyen.model.PaymentRequest;
-import com.adyen.model.PaymentRequest3d;
-import com.adyen.model.PaymentRequest3ds2;
-import com.adyen.model.PaymentResult;
-import com.adyen.model.RequestOptions;
-import com.adyen.model.ThreeDS2ResultRequest;
-import com.adyen.model.ThreeDS2ResultResponse;
+import com.adyen.model.*;
 import com.adyen.model.applicationinfo.ApplicationInfo;
 import com.adyen.model.applicationinfo.MerchantDevice;
 import com.adyen.service.Payment;
@@ -43,6 +34,7 @@ import com.adyen.service.exception.ApiException;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
@@ -51,18 +43,12 @@ import java.util.TimeZone;
 
 import static com.adyen.constants.ApiConstants.SelectedBrand.BOLETO_SANTANDER;
 import static com.adyen.model.PaymentResult.ResultCodeEnum.RECEIVED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for /authorise and /authorise3d
@@ -423,5 +409,19 @@ public class PaymentTest extends BaseTest {
             assertEquals("010", e.getError().getErrorCode());
             assertEquals(403, e.getError().getStatus());
         }
+    }
+
+    @Test
+    public void TestByteArrayToJSONString() throws Exception {
+        Client client = createMockClientFromFile("mocks/authorise-success.json");
+        Payment payment = new Payment(client);
+        PaymentRequest paymentRequest = new PaymentRequest();
+        paymentRequest.mpiData(new ThreeDSecureData().cavv("AQIDBAUGBwgJCgsMDQ4PEBESExQ=".getBytes()));
+        
+        payment.authorise(paymentRequest);
+        
+        String expected = "\"mpiData\":{\"cavv\":\"AQIDBAUGBwgJCgsMDQ4PEBESExQ=\"}";
+        ClientInterface http = client.getHttpClient();
+        verify(http).request(anyString(), contains(expected), any(), eq(false), isNull(), any());
     }
 }


### PR DESCRIPTION
**Description**

Currently, fields of type `byte[]` are serialized as `Number[]`, e.g. `"cavv":[65,81,73,68,66,65,85]`. The API expects a `String`, e.g. `"cavv": "3q2+78r+ur7erb7vyv66vv////8="`.

This PR fixes fields such as [cavv](https://docs.adyen.com/api-explorer/Payment/52/post/authorise#request-mpiData-cavv) used in Classic integrations (i.e. `/authorise` calls). 

**Resources**

* [Authorise a payment with 3D Secure 2 authenticated data](https://docs.adyen.com/online-payments/classic-integrations/api-integration-ecommerce/3d-secure/other-3ds-flows/authorize-mpidata#send-a-payment-authorisation-request) 
* [Authentication-only integration ](https://docs.adyen.com/online-payments/classic-integrations/api-integration-ecommerce/3d-secure/3d-secure-1/3d-secure-1-authentication-only#-authorise3d-response)
