### PR TITLE
[PW-7223] Test Failed because hours are set with 12 hour instead of 24

### DIFF
--- a/src/test/java/com/adyen/DateSerializationTest.java
+++ b/src/test/java/com/adyen/DateSerializationTest.java
@@ -31,7 +31,7 @@ public class DateSerializationTest extends BaseTest {
         cal.set(Calendar.YEAR, 2023);
         cal.set(Calendar.MONTH, 5);
         cal.set(Calendar.DAY_OF_MONTH, 2);
-        cal.set(Calendar.HOUR, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 12);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);


### PR DESCRIPTION
**Description**
This quickly fixes the DateSerializerTests as they were failing because Java Calendar sets hours with 12 hour step instead of 24 hours. 

**Tested scenarios**
