### PR TITLE
[e2y] Fixing dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,11 @@
             <version>5.2</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>5.1.3</version>
+        </dependency>   
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>


### PR DESCRIPTION
**Description**
I'm using Hybris, I have as a dependency the adyen java api library. During the upgrade to the latest version from 14.0.0 version, the call performed to get the paymentMethod has the following exception error:

> INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | SEVERE: Servlet.service() for servlet [DispatcherServlet] in context with path [/yacceleratorstorefront] threw exception [Handler dispatch failed; nested exception is java.lang.NoClassDefFoundError: org/apache/hc/core5/http/ClassicHttpRequest] with root cause
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | java.lang.ClassNotFoundException: org.apache.hc.core5.http.ClassicHttpRequest
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at de.hybris.bootstrap.loader.YURLClassLoader.findClass(YURLClassLoader.java:62)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at de.hybris.bootstrap.loader.YURLClassLoader.loadRegisterAndResolveClass(YURLClassLoader.java:124)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at de.hybris.bootstrap.loader.YURLClassLoader.loadClass(YURLClassLoader.java:112)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at de.hybris.bootstrap.loader.PlatformInPlaceClassLoader.loadClass(PlatformInPlaceClassLoader.java:143)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:555)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:458)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:452)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.security.AccessController.doPrivileged(Native Method)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:451)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at de.hybris.bootstrap.loader.YURLClassLoader.findClass(YURLClassLoader.java:62)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.481 | 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.482 | 	at de.hybris.bootstrap.loader.YURLClassLoader.loadRegisterAndResolveClass(YURLClassLoader.java:124)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.482 | 	at de.hybris.bootstrap.loader.YURLClassLoader.loadClass(YURLClassLoader.java:112)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.482 | 	at de.hybris.bootstrap.loader.PlatformInPlaceClassLoader.loadClass(PlatformInPlaceClassLoader.java:143)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.482 | 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.482 | 	at com.adyen.Client.getHttpClient(Client.java:228)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.482 | 	at com.adyen.service.Resource.request(Resource.java:91)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.482 | 	at com.adyen.service.Resource.request(Resource.java:63)
INFO   | jvm 1    | main    | 2022/11/11 19:11:42.482 | 	at com.adyen.service.Checkout.paymentMethods(Checkout.java:137)

As you can see on the trace, the class `com.adyen.Client.getHttpClient` use the following class `org.apache.hc.core5.http.ClassicHttpRequest` which is placed in a dependency not declared on the pom.xml file. After updating the pom.xml file adding the `org.apache.httpcomponents.core5.httpcore5` artifact, it works.

**Tested scenarios**

1. Add the latest release version as a dependency.
2. Perform a com.adyen.service.Checkout.paymentMethods call to retrieve the payment methods available.
3. Check the error trace on the logs.

