### PR TITLE
Add release.yml file to automatically categorize PRs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Breaking change
+    - title: New Features 💎
+      labels:
+        - Feature
+    - title: Fixes ⛑️
+      labels:
+        - Fix
+    - title: Other Changes 🖇️
+      labels:
+        - "*"


### PR DESCRIPTION
**Description**
This PR will add the release.yml file to automatically categorize PRs in the release notes, based on the linked labels.
