### PR TITLE
Update javax.ws.rs:javax.ws.rs-api:2.1.1 to jakarta.ws.rs:jakarta.ws-rs-api:2.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,9 +232,9 @@
             <version>2.2.8</version>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>2.1.6</version>
         </dependency>
         <dependency>
             <groupId>io.gsonfire</groupId>


### PR DESCRIPTION
**Description**
The `javax.ws.rs:javax.ws.rs-api` dependency was continued under a new artifact called `jakarta.ws.rs:jakarta.ws-rs-api` (no API changes). The old artifact was giving us build errors using Gradle 7.5 due to specifying `${packaging.type}` in the `<packaging>` tag in the POM. The new artifact specifies `bundle` instead which does work. See also this issue: https://github.com/jakartaee/rest/issues/572.

**Tested scenarios**
We've tested this solution by using the following workaround for our app, which makes everything compile and run correctly again:
```
implementation("com.adyen:adyen-java-api-library:18.1.3") {
    exclude("javax.ws.rs", "javax.ws.rs-api")
}
implementation("jakarta.ws.rs:jakarta.ws.rs-api:2.1.6")
```

**Fixed issue**:  n/a
