### PR TITLE
Fixing the constructor with config object in Client.java

### DIFF
--- a/src/main/java/com/adyen/Client.java
+++ b/src/main/java/com/adyen/Client.java
@@ -84,6 +84,7 @@ public class Client {
 
     public Client(Config config) {
         this.config = config;
+        this.setEnvironment(config.environment, config.liveEndpointUrlPrefix);
     }
 
     public Client(String username, String password, Environment environment, String applicationName) {

--- a/src/main/java/com/adyen/Config.java
+++ b/src/main/java/com/adyen/Config.java
@@ -299,10 +299,10 @@ public class Config {
         this.managementEndpoint = managementEndpoint;
     }
 
-    public String getLiveEndpointUrlPrefix(){
+    public String getLiveEndpointUrlPrefix() {
         return this.liveEndpointUrlPrefix;
     }
-    public void setLiveEndpointUrlPrefix(String liveEndpointUrlPrefix){
+    public void setLiveEndpointUrlPrefix(String liveEndpointUrlPrefix) {
         this.liveEndpointUrlPrefix = liveEndpointUrlPrefix;
     }
 }

--- a/src/main/java/com/adyen/Config.java
+++ b/src/main/java/com/adyen/Config.java
@@ -72,6 +72,7 @@ public class Config {
     protected String clientKeyStorePassword;
     protected String legalEntityManagementEndpoint;
     protected String managementEndpoint;
+    protected String liveEndpointUrlPrefix;
 
     public Config() {
         // do nothing
@@ -296,5 +297,12 @@ public class Config {
 
     public void setManagementEndpoint(String managementEndpoint) {
         this.managementEndpoint = managementEndpoint;
+    }
+
+    public String getLiveEndpointUrlPrefix(){
+        return this.liveEndpointUrlPrefix;
+    }
+    public void setLiveEndpointUrlPrefix(String liveEndpointUrlPrefix){
+        this.liveEndpointUrlPrefix = liveEndpointUrlPrefix;
     }
 }

--- a/src/test/java/com/adyen/ClientTest.java
+++ b/src/test/java/com/adyen/ClientTest.java
@@ -23,6 +23,37 @@ public class ClientTest {
     private String apiKey;
 
     @Test
+    public void testConfigTestClient() {
+        Config config = new Config();
+        config.setEnvironment(Environment.TEST);
+        config.setApiKey(apiKey);
+        Client client = new Client(config);
+
+        Assert.assertEquals(Environment.TEST, client.getConfig().getEnvironment());
+        Assert.assertEquals("https://checkout-test.adyen.com/checkout", client.getConfig().getCheckoutEndpoint());
+    }
+
+    @Test
+    public void testConfigLiveClient() {
+        Config config = new Config();
+        config.setEnvironment(Environment.LIVE);
+        config.setLiveEndpointUrlPrefix("prefix");
+        config.setApiKey(apiKey);
+        Client client = new Client(config);
+        Assert.assertEquals(Environment.LIVE, client.getConfig().getEnvironment());
+        Assert.assertEquals("https://prefix-checkout-live.adyenpayments.com/checkout", client.getConfig().getCheckoutEndpoint());
+    }
+
+    @Test
+    public void testConfigLiveNoPrefixCheckoutClient() {
+        Config config = new Config();
+        config.setEnvironment(Environment.LIVE);
+        config.setApiKey(apiKey);
+        IllegalArgumentException ex = Assert.assertThrows(IllegalArgumentException.class, () -> {new Client(config).getConfig().getCheckoutEndpoint();});
+        Assert.assertEquals(ex.getMessage(), "Please provide your unique live url prefix on the setEnvironment() call on the Client or provide checkoutEndpoint in your config object.");
+    }
+
+    @Test
     public void testClientCertificateAuth() {
         Client client = new Client(trustStore, clientKeyStore, clientKeyStorePassword, apiKey, null);
 


### PR DESCRIPTION
**Description**
This PR fixes the problem we found with initialising the Client with an config object. In order to make it make sense, I added a getter/setter for the liveEndpointUrlPrefix like we did in the .NET library. This way we keep our current implementation of the client but also support the config constructor.

**Tested scenarios**
UT
