### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @AlexandrosMor @wboereboom @Morerice @michaelpaul @jillingk @antolo-arch
+* @Adyen/api-libraries-reviewers


### PR DESCRIPTION
**Description**
this PR sets the ITT team as codeowner for the library