### PR TITLE
Remove <br /> from Javadoc (Checkout)

### DIFF
--- a/src/main/java/com/adyen/service/Checkout.java
+++ b/src/main/java/com/adyen/service/Checkout.java
@@ -602,8 +602,8 @@ public class Checkout extends ApiKeyAuthenticatedService {
      * GET /storedPaymentMethods
      *
      * @param queryParams  (optional)
-     *    merchantAccount: Your merchant account. (optional)<br />
-     *    shopperReference: Your reference to uniquely identify this shopper, for example user ID or account ID. Minimum length: 3 characters. (optional)<br />
+     *    merchantAccount: Your merchant account. (optional)
+     *    shopperReference: Your reference to uniquely identify this shopper, for example user ID or account ID. Minimum length: 3 characters. (optional)
      * @return ListStoredPaymentMethodsResponse
      * @throws ApiException if it fails to make API call
      */
@@ -627,8 +627,8 @@ public class Checkout extends ApiKeyAuthenticatedService {
      *
      * @param recurringId String
      * @param queryParams  (optional)
-     *    merchantAccount: Your merchant account. (optional)<br />
-     *    shopperReference: Your reference to uniquely identify this shopper, for example user ID or account ID. Minimum length: 3 characters. (optional)<br />
+     *    merchantAccount: Your merchant account. (optional)
+     *    shopperReference: Your reference to uniquely identify this shopper, for example user ID or account ID. Minimum length: 3 characters. (optional)
      * @throws ApiException if it fails to make API call
      */
     public void deleteStoredPaymentDetails(String recurringId, Map<String, String> queryParams) throws ApiException, IOException {


### PR DESCRIPTION
**Description**
The generation of Checkout-v70 has introduced the `<br >` element in the javadoc.

This PR removed those elements. The corresponding Mustache template should be updated to make sure it won't happen again during the new code generation.

**Tested scenarios**
n/a


