### PR TITLE
ApiException doesn't provide ApiError with error information

### DIFF
--- a/src/main/java/com/adyen/model/ApiError.java
+++ b/src/main/java/com/adyen/model/ApiError.java
@@ -21,10 +21,13 @@
 package com.adyen.model;
 
 import com.adyen.model.marketpay.ErrorFieldType;
+import com.google.gson.*;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 
+import java.io.IOException;
 import java.util.List;
-
 
 import static com.adyen.util.Util.toIndentedString;
 
@@ -97,6 +100,67 @@ public class ApiError {
     public void setInvalidFields(List<ErrorFieldType> invalidFields) {
         this.invalidFields = invalidFields;
     }
+
+    /**
+     * Create an instance of ApiError given an JSON string
+     * @param jsonString
+     * @return
+     * @throws IOException
+     */
+    public static ApiError fromJson(String jsonString) throws IOException {
+
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(ApiError.class, new ApiErrorAdapter())
+                .create();
+
+        return gson.fromJson(jsonString, ApiError.class);
+    }
+
+    // custom deserialization of ApiError to support both RFC7807 format and the existing ServiceError schema
+    static class ApiErrorAdapter extends TypeAdapter<ApiError> {
+        private final Gson gson = new Gson();
+
+        @Override
+        public void write(JsonWriter out, ApiError value) throws IOException {
+            // nothing to do
+        }
+
+        @Override
+        public ApiError read(JsonReader jsonReader) throws IOException {
+            ApiError apiError;
+
+            JsonObject jsonObject = gson.fromJson(jsonReader, JsonObject.class);
+            JsonElement typeJsonElement = jsonObject.get("type");
+
+            if (typeJsonElement != null) {
+                // convert RFC7807 payload to ApiError
+                apiError = new ApiError();
+                apiError.errorType = getStringValue(jsonObject, "type");
+                apiError.status = getIntValue(jsonObject, "status");
+                apiError.message = getStringValue(jsonObject, "detail");
+                apiError.invalidFields = getListValue(jsonObject, "invalidFields");
+                apiError.errorCode = getStringValue(jsonObject, "errorCode");
+            } else {
+                // map ServiceError to ApiError
+                apiError = gson.fromJson(jsonObject, ApiError.class);
+            }
+
+            return apiError;
+        }
+
+        String getStringValue(JsonObject jsonObject, String field) {
+            return jsonObject.get(field) != null ? jsonObject.get(field).getAsString() : null;
+        }
+
+        Integer getIntValue(JsonObject jsonObject, String field) {
+            return jsonObject.get(field) != null ? jsonObject.get(field).getAsInt() : null;
+        }
+
+        List getListValue(JsonObject jsonObject, String field) {
+            return jsonObject.get(field) != null ? jsonObject.get(field).getAsJsonArray().asList() : null;
+        }
+    }
+
 
     @Override
     public String toString() {

--- a/src/main/java/com/adyen/service/resource/Resource.java
+++ b/src/main/java/com/adyen/service/resource/Resource.java
@@ -25,6 +25,7 @@ import com.adyen.Service;
 import com.adyen.constants.ApiConstants;
 import com.adyen.httpclient.ClientInterface;
 import com.adyen.httpclient.HTTPClientException;
+import com.adyen.model.ApiError;
 import com.adyen.model.RequestOptions;
 import com.adyen.service.exception.ApiException;
 import com.google.gson.Gson;
@@ -113,6 +114,7 @@ public class Resource {
         } catch (HTTPClientException e) {
             apiException = new ApiException(e.getMessage(), e.getCode(), e.getResponseHeaders());
             apiException.setResponseBody(e.getResponseBody());
+            apiException.setError(ApiError.fromJson(e.getResponseBody()));
         }
         throw apiException;
     }

--- a/src/test/java/com/adyen/service/ResourceTest.java
+++ b/src/test/java/com/adyen/service/ResourceTest.java
@@ -113,4 +113,41 @@ public class ResourceTest extends BaseTest {
             assertTrue(e.getResponseBody().contains("010"));
         }
     }
+
+    @Test
+    public void testValidationException() throws IOException {
+        Client client = createMockClientForErrors(422, "mocks/response-validation-error.json");
+
+        when(serviceMock.getClient()).thenReturn(client);
+        try {
+            Resource resource = new Resource(serviceMock, "", null);
+            String response = resource.request("request");
+
+            fail("Expected exception");
+        } catch (ApiException e) {
+            assertEquals(422, e.getStatusCode());
+            assertNotNull(e.getError());
+            assertEquals("validation", e.getError().getErrorType());
+            assertEquals("Required field 'reference' is not provided.", e.getError().getMessage());
+        }
+    }
+
+    @Test
+    public void testErrorRfc7807ValidationException() throws IOException {
+        Client client = createMockClientForErrors(422, "mocks/response-validation-error-rfc7807.json");
+
+        when(serviceMock.getClient()).thenReturn(client);
+        try {
+            Resource resource = new Resource(serviceMock, "", null);
+            String response = resource.request("request");
+
+            fail("Expected exception");
+        } catch (ApiException e) {
+            assertEquals(422, e.getStatusCode());
+            assertNotNull(e.getError());
+            assertEquals("https://docs.adyen.com/errors/validation", e.getError().getErrorType());
+            assertEquals("Invalid legal entity information provided", e.getError().getMessage());
+            assertEquals(1, e.getError().getInvalidFields().size());
+        }
+    }
 }

--- a/src/test/resources/mocks/response-validation-error-rfc7807.json
+++ b/src/test/resources/mocks/response-validation-error-rfc7807.json
@@ -1,0 +1,14 @@
+{
+  "type": "https://docs.adyen.com/errors/validation",
+  "title": "The request is missing required fields or contains invalid data.",
+  "status": 422,
+  "detail": "Invalid legal entity information provided",
+  "requestId": "1234567890",
+  "invalidFields": [
+    {
+      "name": "type",
+      "message": "Type was not provided, or was invalid. Possible values: [organization, individual, soleProprietorship, trust, unincorporatedPartnership]."
+    }
+  ],
+  "errorCode": "30_102"
+}

--- a/src/test/resources/mocks/response-validation-error.json
+++ b/src/test/resources/mocks/response-validation-error.json
@@ -1,0 +1,7 @@
+{
+  "status" : 422,
+  "errorCode" : "130",
+  "message" : "Required field 'reference' is not provided.",
+  "errorType" : "validation",
+  "pspReference" : "ABCDEFGHIJKLMNO"
+}


### PR DESCRIPTION
**Description**
When the API returns an error the `ApiException`does not provide/map the ApiError object
```
        } catch (ApiException e) {
            log.error(e.getMessage()); // HTTP Exception
            log.error(e.getResponseBody());  // {"status":422,"errorCode":"803","message":.....
            log.error(e.getError()); // null
```
This PR implements a GSON adapter to map the JSON error to the ApiError object, supporting both format `RFC7807` (returned by LEM and platform APIs) and `ServiceError` legacy format (Checkout)

**Tested scenarios**
<!-- Description of tested scenarios -->
Added 2 unit tests in `ResourceTest` class
Tested with Adyen Java sample application

