### PR TITLE
Put back JsonProperty as it's now impossible to deserialize the json object

### DIFF
--- a/src/main/java/com/adyen/model/notification/NotificationRequest.java
+++ b/src/main/java/com/adyen/model/notification/NotificationRequest.java
@@ -35,6 +35,7 @@ public class NotificationRequest {
     private String live = null;
 
     @SerializedName("notificationItems")
+    @JsonProperty("notificationItems")
     private List<NotificationRequestItemContainer> notificationItemContainers = null;
 
     public String getLive() {


### PR DESCRIPTION
**Description**
Put back the @JsonProperty name to be able to deserialize the object from JSON

**Tested scenarios**
With and without the annotation

**Fixed issue**: 
