### PR TITLE
Add SaleToAcquirerDataSerializer deserialisation

### DIFF
--- a/src/main/java/com/adyen/model/terminal/SaleToAcquirerData.java
+++ b/src/main/java/com/adyen/model/terminal/SaleToAcquirerData.java
@@ -20,13 +20,18 @@
  */
 package com.adyen.model.terminal;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.codec.binary.Base64;
+
 import com.adyen.model.applicationinfo.ApplicationInfo;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.apache.commons.codec.binary.Base64;
-
-import java.util.Map;
-import java.util.Objects;
 
 public class SaleToAcquirerData {
 
@@ -228,5 +233,15 @@ public class SaleToAcquirerData {
     public String toBase64() {
         String json = PRETTY_PRINT_GSON.toJson(this);
         return new String(Base64.encodeBase64(json.getBytes()));
+    }
+
+    public static SaleToAcquirerData fromBase64(String base64) {
+        byte[] decoded = Base64.decodeBase64(base64);
+        try (Reader reader = new InputStreamReader(new ByteArrayInputStream(decoded))) {
+            return PRETTY_PRINT_GSON.fromJson(reader, SaleToAcquirerData.class);
+        }
+        catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/src/main/java/com/adyen/serializer/SaleToAcquirerDataSerializer.java
+++ b/src/main/java/com/adyen/serializer/SaleToAcquirerDataSerializer.java
@@ -1,16 +1,29 @@
 package com.adyen.serializer;
 
+import java.lang.reflect.Type;
+
 import com.adyen.model.terminal.SaleToAcquirerData;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
-import java.lang.reflect.Type;
+public class SaleToAcquirerDataSerializer implements
+        JsonSerializer<SaleToAcquirerData>,
+        JsonDeserializer<SaleToAcquirerData> {
 
-public class SaleToAcquirerDataSerializer implements JsonSerializer<SaleToAcquirerData> {
-
-    public JsonElement serialize(SaleToAcquirerData saleToAcquirerData, Type typeOfSrc, JsonSerializationContext context) {
+    @Override
+    public JsonElement serialize(SaleToAcquirerData saleToAcquirerData, Type typeOfSrc,
+            JsonSerializationContext context) {
         return new JsonPrimitive(saleToAcquirerData.toBase64());
+    }
+
+    @Override
+    public SaleToAcquirerData deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        return SaleToAcquirerData.fromBase64(json.getAsString());
     }
 }


### PR DESCRIPTION
**Description**
Adds missing deserialization of SaleToAcquirerData for SaleToPOIResponses, e.g. when using the payment provider Twint in Switzerland

**Tested scenarios**
* Base 64 Encodeded SaleToAcquirerData was parsed correctly. 

**Fixed issue**:  #[1037](https://github.com/Adyen/adyen-java-api-library/issues/1037)
