### PR TITLE
[ITT-599] Implement caching of NexoDerivedKey for TerminalLocalAPI.

### DIFF
--- a/src/test/java/com/adyen/NexoCryptoTest.java
+++ b/src/test/java/com/adyen/NexoCryptoTest.java
@@ -56,9 +56,9 @@ public class NexoCryptoTest extends BaseTest {
         MessageHeader messageHeader = terminalAPIRequest.getSaleToPOIRequest().getMessageHeader();
         String requestJson = PRETTY_PRINT_GSON.toJson(terminalAPIRequest);
 
-        NexoCrypto nexoCrypto = new NexoCrypto();
+        NexoCrypto nexoCrypto = new NexoCrypto(testSecurityKey);
 
-        SaleToPOISecuredMessage encryptedMessage = nexoCrypto.encrypt(requestJson, messageHeader, testSecurityKey);
+        SaleToPOISecuredMessage encryptedMessage = nexoCrypto.encrypt(requestJson, messageHeader);
         assertNotNull(encryptedMessage);
         assertNotNull(encryptedMessage.getNexoBlob());
         assertNotNull(encryptedMessage.getMessageHeader());
@@ -71,21 +71,17 @@ public class NexoCryptoTest extends BaseTest {
         MessageHeader messageHeader = terminalAPIRequest.getSaleToPOIRequest().getMessageHeader();
         String requestJson = PRETTY_PRINT_GSON.toJson(terminalAPIRequest);
 
-        NexoCrypto nexoCrypto = new NexoCrypto();
+        NexoCrypto nexoCrypto = new NexoCrypto(testSecurityKey);
 
-        SaleToPOISecuredMessage encryptedMessage = nexoCrypto.encrypt(requestJson, messageHeader, testSecurityKey);
-        String decryptedMessage = nexoCrypto.decrypt(encryptedMessage, testSecurityKey);
+        SaleToPOISecuredMessage encryptedMessage = nexoCrypto.encrypt(requestJson, messageHeader);
+        String decryptedMessage = nexoCrypto.decrypt(encryptedMessage);
         assertNotNull(decryptedMessage);
         assertEquals(requestJson, decryptedMessage);
     }
 
     @Test(expected = NexoCryptoException.class)
     public void testEncryptionWithInvalidSecurityKey() throws Exception {
-        TerminalAPIRequest terminalAPIRequest = createTerminalAPIPaymentRequest();
-        MessageHeader messageHeader = terminalAPIRequest.getSaleToPOIRequest().getMessageHeader();
-        String requestJson = PRETTY_PRINT_GSON.toJson(terminalAPIRequest);
-
-        new NexoCrypto().encrypt(requestJson, messageHeader, new SecurityKey());
+        new NexoCrypto(new SecurityKey());
     }
 
     @Test(expected = NexoCryptoException.class)
@@ -94,14 +90,14 @@ public class NexoCryptoTest extends BaseTest {
         MessageHeader messageHeader = terminalAPIRequest.getSaleToPOIRequest().getMessageHeader();
         String requestJson = PRETTY_PRINT_GSON.toJson(terminalAPIRequest);
 
-        NexoCrypto nexoCrypto = new NexoCrypto();
+        NexoCrypto nexoCrypto = new NexoCrypto(testSecurityKey);
 
-        SaleToPOISecuredMessage encryptedMessage = nexoCrypto.encrypt(requestJson, messageHeader, testSecurityKey);
+        SaleToPOISecuredMessage encryptedMessage = nexoCrypto.encrypt(requestJson, messageHeader);
 
         byte[] modifiedHmac = new byte[32];
         new Random().nextBytes(modifiedHmac);
         encryptedMessage.getSecurityTrailer().setHmac(modifiedHmac);
 
-        nexoCrypto.decrypt(encryptedMessage, testSecurityKey);
+        nexoCrypto.decrypt(encryptedMessage);
     }
 }

--- a/src/test/java/com/adyen/TerminalLocalAPITest.java
+++ b/src/test/java/com/adyen/TerminalLocalAPITest.java
@@ -59,17 +59,15 @@ public class TerminalLocalAPITest extends BaseTest {
     @Test
     public void syncPaymentRequestSuccess() throws Exception {
         Client client = createMockClientFromFile("mocks/terminal-api/payment-local-success.json");
-        TerminalLocalAPI terminalLocalApi = new TerminalLocalAPI(client);
-
-        TerminalAPIRequest terminalAPIPaymentRequest = createTerminalAPIPaymentRequest();
-
         SecurityKey securityKey = new SecurityKey();
         securityKey.setKeyVersion(1);
         securityKey.setAdyenCryptoVersion(1);
         securityKey.setKeyIdentifier("CryptoKeyIdentifier12345");
         securityKey.setPassphrase("p@ssw0rd123456");
+        TerminalLocalAPI terminalLocalApi = new TerminalLocalAPI(client, securityKey);
 
-        TerminalAPIResponse terminalAPIResponse = terminalLocalApi.request(terminalAPIPaymentRequest, securityKey);
+        TerminalAPIRequest terminalAPIPaymentRequest = createTerminalAPIPaymentRequest();
+        TerminalAPIResponse terminalAPIResponse = terminalLocalApi.request(terminalAPIPaymentRequest);
 
         assertNotNull(terminalAPIResponse);
         assertNotNull(terminalAPIResponse.getSaleToPOIResponse());


### PR DESCRIPTION
**Description**
The Adyen Java API library currently derives a key for every single local terminal API request instead of caching it. This has a performance impact, especially when using the library on Android devices or Adyen Android terminals

**Tested scenarios**
All unit tests.

**Fixed issue**:  ITT-599
