### PR TITLE
ITT-542 Replace configuration options with SSLContext and HostnameVerifier option

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,69 @@ System.setProperty("https.proxyUser", "squid");
 System.setProperty("https.proxyPassword", "ward");
 ~~~~
 
+### Client certificate authentication
+~~~~ java
+// Import the required classes
+import com.adyen.Client;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.security.KeyStore;
+
+// Initialize a KeyManagerFactory with the client KeyStore and password
+KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+keyManagerFactory.init(clientKeyStore, clientKeyStorePassword);
+
+// Create a TrustManagerFactory that trusts the CAs in our Trust KeyStore
+TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+trustManagerFactory.init(trustStore);
+
+// Create an SSLContext with the desired protocol that uses our KeyManagers and TrustManagers
+SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
+
+Client client = new Client(sslContext, apiKey, region);
+// Use the client
+~~~~
+
+### Local terminal API
+~~~~ java
+// Import the required classes
+import com.adyen.Client;
+import com.adyen.Config;
+import com.adyen.enums.Environment;
+import com.adyen.httpclient.TerminalLocalAPIHostnameVerifier;
+import com.adyen.service.TerminalLocalAPI;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+
+// Create a KeyStore for the terminal certificate
+KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+keyStore.load(null, null);
+keyStore.setCertificateEntry("adyenRootCertificate", adyenRootCertificate);
+
+// Create a TrustManagerFactory that trusts the CAs in our KeyStore
+TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+trustManagerFactory.init(keyStore);
+
+// Create an SSLContext with the desired protocol that uses our TrustManagers
+SSLContext sslContext = SSLContext.getInstance("SSL");
+sslContext.init(null, trustManagerFactory.getTrustManagers(), new SecureRandom());
+
+// Configure a client for TerminalLocalAPI
+Config config = new Config();
+config.setEnvironment(environment);
+config.setTerminalApiLocalEndpoint("https://" + terminalIpAddress);
+config.setSSLContext(sslContext);
+config.setHostnameVerifier(new TerminalLocalAPIHostnameVerifier(environment));
+Client client = new Client(config);
+
+TerminalLocalAPI terminalLocalAPI = new TerminalLocalAPI(client, securityKey);
+// Use TerminalLocalAPI
+~~~~
+
 ### Example integrations
  
 For a closer look at how our Java library works, you can clone one of our example integrations:

--- a/src/main/java/com/adyen/Client.java
+++ b/src/main/java/com/adyen/Client.java
@@ -25,7 +25,7 @@ import com.adyen.enums.Region;
 import com.adyen.httpclient.AdyenHttpClient;
 import com.adyen.httpclient.ClientInterface;
 
-import java.security.KeyStore;
+import javax.net.ssl.SSLContext;
 
 public class Client {
     private ClientInterface httpClient;
@@ -54,17 +54,13 @@ public class Client {
      * Use this constructor to create client for client certificate authentication along with API key.
      * Note: Client certificate authentication is only applicable for PAL and Checkout services in LIVE,
      * Other services will just use API key for authentication.
-     * @param trustStore Trust store containing server certificate
-     * @param clientKeyStore Client Key store containing client certificate and key
-     * @param clientKeyStorePassword Password for client key store
+     * @param sslContext {@link SSLContext} for client certificate authentication
      * @param apiKey Adyen API Key
      * @param region Data center region (EU/US/AU), default EU if not provided
      */
-    public Client(KeyStore trustStore, KeyStore clientKeyStore, String clientKeyStorePassword, String apiKey, Region region) {
+    public Client(SSLContext sslContext, String apiKey, Region region) {
         this(apiKey, Environment.LIVE);
-        this.config.setClientKeyStorePassword(clientKeyStorePassword);
-        this.config.setClientKeyStore(clientKeyStore);
-        this.config.setTrustKeyStore(trustStore);
+        this.config.setSSLContext(sslContext);
         this.config.setEndpoint(ENDPOINT_CERT_LIVE);
 
         if (region != null) {

--- a/src/main/java/com/adyen/Config.java
+++ b/src/main/java/com/adyen/Config.java
@@ -21,16 +21,9 @@
 package com.adyen;
 
 import com.adyen.enums.Environment;
-import com.adyen.util.CertificateUtil;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
 
 public class Config {
     protected String username;
@@ -53,13 +46,9 @@ public class Config {
     //Terminal API Specific
     protected String terminalApiCloudEndpoint;
     protected String terminalApiLocalEndpoint;
-    protected Certificate terminalCertificate;
-
-    // Client certificate authentication
-    protected KeyStore trustKeyStore;
-    protected KeyStore clientKeyStore;
-    protected String clientKeyStorePassword;
     protected String liveEndpointUrlPrefix;
+    protected SSLContext sslContext;
+    protected HostnameVerifier hostnameVerifier;
 
     public Config() {
         // do nothing
@@ -165,59 +154,37 @@ public class Config {
         this.readTimeoutMillis = readTimeoutMillis;
     }
 
-    public Certificate getTerminalCertificate() {
-        return terminalCertificate;
-    }
-
-    public void setTerminalCertificate(Certificate terminalCertificate) {
-        this.terminalCertificate = terminalCertificate;
-    }
-
-    public void setTerminalCertificate(String terminalCertificatePath) throws FileNotFoundException, CertificateException {
-        this.terminalCertificate = CertificateUtil.loadCertificate(terminalCertificatePath);
-    }
-
-    public void setTerminalCertificate(InputStream terminalCertificateStream) throws CertificateException {
-        this.terminalCertificate = CertificateUtil.loadCertificate(terminalCertificateStream);
-    }
-
-       public KeyStore getTrustKeyStore() {
-        return trustKeyStore;
-    }
-
-    public void setTrustKeyStore(KeyStore trustKeyStore) {
-        this.trustKeyStore = trustKeyStore;
-    }
-
-    public void setTrustKeyStore(String trustKeyStorePath, String keyStoreType, String password) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
-        this.trustKeyStore = CertificateUtil.loadKeyStore(trustKeyStorePath, keyStoreType, password);
-    }
-
-    public KeyStore getClientKeyStore() {
-        return clientKeyStore;
-    }
-
-    public void setClientKeyStore(KeyStore clientKeyStore) {
-        this.clientKeyStore = clientKeyStore;
-    }
-
-    public void setClientKeyStore(String clientKeyStorePath, String keyStoreType, String clientKeyStorePassword) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
-        this.clientKeyStorePassword = clientKeyStorePassword;
-        this.clientKeyStore = CertificateUtil.loadKeyStore(clientKeyStorePath, keyStoreType, clientKeyStorePassword);
-    }
-
-    public String getClientKeyStorePassword() {
-        return clientKeyStorePassword;
-    }
-
-    public void setClientKeyStorePassword(String clientKeyStorePassword) {
-        this.clientKeyStorePassword = clientKeyStorePassword;
-    }
-
     public String getLiveEndpointUrlPrefix() {
         return this.liveEndpointUrlPrefix;
     }
     public void setLiveEndpointUrlPrefix(String liveEndpointUrlPrefix) {
         this.liveEndpointUrlPrefix = liveEndpointUrlPrefix;
+    }
+
+    public SSLContext getSSLContext() {
+        return sslContext;
+    }
+
+    /**
+     * Sets the {@link SSLContext} for the {@link com.adyen.httpclient.AdyenHttpClient}.
+     *
+     * @param sslContext The {@link SSLContext}
+     */
+    public void setSSLContext(SSLContext sslContext) {
+        this.sslContext = sslContext;
+    }
+
+    public HostnameVerifier getHostnameVerifier() {
+        return hostnameVerifier;
+    }
+
+    /**
+     * Sets the {@link HostnameVerifier} for the {@link com.adyen.httpclient.AdyenHttpClient}.
+     *
+     * @param hostnameVerifier The {@link HostnameVerifier}
+     * @see com.adyen.httpclient.TerminalLocalAPIHostnameVerifier
+     */
+    public void setHostnameVerifier(HostnameVerifier hostnameVerifier) {
+        this.hostnameVerifier = hostnameVerifier;
     }
 }

--- a/src/main/java/com/adyen/httpclient/TerminalLocalAPIHostnameVerifier.java
+++ b/src/main/java/com/adyen/httpclient/TerminalLocalAPIHostnameVerifier.java
@@ -1,0 +1,33 @@
+package com.adyen.httpclient;
+
+import com.adyen.enums.Environment;
+import com.adyen.terminal.security.TerminalCommonNameValidator;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.security.cert.X509Certificate;
+
+public final class TerminalLocalAPIHostnameVerifier implements HostnameVerifier {
+    private final Environment environment;
+
+    public TerminalLocalAPIHostnameVerifier(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        try {
+            if (session.getPeerCertificates() != null && session.getPeerCertificates().length > 0) {
+                // Assume the first certificate is the leaf, since chain will be ordered, according to Java documentation:
+                // https://docs.oracle.com/javase/7/docs/api/javax/net/ssl/SSLSession.html#getPeerCertificates()
+                X509Certificate certificate = (X509Certificate) session.getPeerCertificates()[0];
+                return TerminalCommonNameValidator.validateCertificate(certificate, environment);
+            }
+            return false;
+        } catch (SSLPeerUnverifiedException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/adyen/ClientTest.java
+++ b/src/test/java/com/adyen/ClientTest.java
@@ -6,18 +6,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import java.security.KeyStore;
+import javax.net.ssl.SSLContext;
 
 public class ClientTest {
 
     @Mock
-    private KeyStore trustStore;
-
-    @Mock
-    private KeyStore clientKeyStore;
-
-    @Mock
-    private String clientKeyStorePassword;
+    private SSLContext clientCertificateAuthSSLContext;
 
     @Mock
     private String apiKey;
@@ -55,13 +49,13 @@ public class ClientTest {
 
     @Test
     public void testClientCertificateAuth() {
-        Client client = new Client(trustStore, clientKeyStore, clientKeyStorePassword, apiKey, null);
+        Client client = new Client(clientCertificateAuthSSLContext, apiKey, null);
         Assert.assertEquals(Environment.LIVE, client.getConfig().getEnvironment());
     }
 
     @Test
     public void testClientCertificateAuth_AU() {
-        Client client = new Client(trustStore, clientKeyStore, clientKeyStorePassword, apiKey, Region.AU);
+        Client client = new Client(clientCertificateAuthSSLContext, apiKey, Region.AU);
 
         Assert.assertEquals(Environment.LIVE, client.getConfig().getEnvironment());
         Assert.assertEquals("https://checkoutcert-live-au.adyen.com/checkout", client.getConfig().getCheckoutEndpoint());
@@ -70,7 +64,7 @@ public class ClientTest {
 
     @Test
     public void testClientCertificateAuth_US() {
-        Client client = new Client(trustStore, clientKeyStore, clientKeyStorePassword, apiKey, Region.US);
+        Client client = new Client(clientCertificateAuthSSLContext, apiKey, Region.US);
 
         Assert.assertEquals(Environment.LIVE, client.getConfig().getEnvironment());
         Assert.assertEquals("https://checkoutcert-live-us.adyen.com/checkout", client.getConfig().getCheckoutEndpoint());


### PR DESCRIPTION
**Description**
Some configuration permutations were not possible with the current implementation. This change allows to configure the SSLContext and HostnameVerifier to account for those.

**Tested scenarios**
TerminalLocalApi use cases.

**Fixed issue**:  IT-542
