### PR TITLE
Java 17 and Java 20 CI support

### DIFF
--- a/.github/workflows/javaci.yml
+++ b/.github/workflows/javaci.yml
@@ -5,14 +5,16 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java: [ '11', '17' ]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.Java }}
         uses: actions/setup-java@v3
 
         with:
-          java-version: '11'
+          java-version: ${{ matrix.java }}
           distribution: 'adopt'
           
       - name: Run the tests with Maven

--- a/.github/workflows/javaci.yml
+++ b/.github/workflows/javaci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17' ]
+        java: [ '11', '17', '20' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.Java }}

--- a/src/test/java/com/adyen/BaseTest.java
+++ b/src/test/java/com/adyen/BaseTest.java
@@ -45,6 +45,7 @@ import com.adyen.model.payment.ThreeDS2RequestData;
 import com.adyen.model.terminal.TerminalAPIRequest;
 import com.adyen.model.additionalData.InvoiceLine;
 import com.adyen.model.payment.PaymentRequest;
+import com.adyen.terminal.serialization.XMLGregorianCalendarTypeAdapter;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -70,7 +71,9 @@ import static org.mockito.Mockito.when;
 public class BaseTest {
     protected final ApplicationInfo applicationInfo = new ApplicationInfo()
             .adyenLibrary(new CommonField().name(LIB_NAME).version(LIB_VERSION));
-    protected static final Gson PRETTY_PRINT_GSON = new GsonBuilder().setPrettyPrinting().create();
+    protected static final Gson PRETTY_PRINT_GSON = new GsonBuilder()
+            .registerTypeHierarchyAdapter(XMLGregorianCalendar.class, new XMLGregorianCalendarTypeAdapter())
+            .setPrettyPrinting().create();
     public static final String USER_AGENT = "User-Agent:Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36";
 
     /**


### PR DESCRIPTION
**Description**

This branch adds Java 17 support to the CI, so our library can be compiled with the JDK 17 (even if we stay 11 compatible).

**Tested scenarios**

None yet, to be done.
