### PR TITLE
Additional cleanup to support java17

### DIFF
--- a/.github/workflows/javaci.yml
+++ b/.github/workflows/javaci.yml
@@ -18,4 +18,4 @@ jobs:
           distribution: 'adopt'
           
       - name: Run the tests with Maven
-        run: mvn -B test --no-transfer-progress
+        run: mvn -B clean test package --no-transfer-progress

--- a/.github/workflows/javaci.yml
+++ b/.github/workflows/javaci.yml
@@ -5,14 +5,16 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java: [ '11', '17' ]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.Java }}
         uses: actions/setup-java@v3
 
         with:
-          java-version: '11'
+          java-version: ${{ matrix.java }}
           distribution: 'adopt'
           
       - name: Run the tests with Maven

--- a/.github/workflows/javaci.yml
+++ b/.github/workflows/javaci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17' ]
+        java: [ '11', '17', '20' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.Java }}

--- a/src/main/java/com/adyen/ApiKeyAuthenticatedService.java
+++ b/src/main/java/com/adyen/ApiKeyAuthenticatedService.java
@@ -21,7 +21,6 @@
 package com.adyen;
 
 /**
- * <h1>ApiKeyAuthenticatedService</h1>
  * The ApiKeyAuthenticatedService is an interface to enable a child service to support API key authentication feature.
  */
 public class ApiKeyAuthenticatedService extends Service {

--- a/src/test/java/com/adyen/BaseTest.java
+++ b/src/test/java/com/adyen/BaseTest.java
@@ -45,6 +45,7 @@ import com.adyen.model.payment.ThreeDS2RequestData;
 import com.adyen.model.terminal.TerminalAPIRequest;
 import com.adyen.model.additionalData.InvoiceLine;
 import com.adyen.model.payment.PaymentRequest;
+import com.adyen.terminal.serialization.XMLGregorianCalendarTypeAdapter;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -70,7 +71,9 @@ import static org.mockito.Mockito.when;
 public class BaseTest {
     protected final ApplicationInfo applicationInfo = new ApplicationInfo()
             .adyenLibrary(new CommonField().name(LIB_NAME).version(LIB_VERSION));
-    protected static final Gson PRETTY_PRINT_GSON = new GsonBuilder().setPrettyPrinting().create();
+    protected static final Gson PRETTY_PRINT_GSON = new GsonBuilder()
+            .registerTypeHierarchyAdapter(XMLGregorianCalendar.class, new XMLGregorianCalendarTypeAdapter())
+            .setPrettyPrinting().create();
     public static final String USER_AGENT = "User-Agent:Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36";
 
     /**

--- a/src/test/java/com/adyen/BaseTest.java
+++ b/src/test/java/com/adyen/BaseTest.java
@@ -209,9 +209,9 @@ public class BaseTest {
         // Use OpenInvoice Provider (klarna, ratepay)
         paymentRequest.selectedBrand("klarna");
 
-        Long itemAmount = new Long("9000");
-        Long itemVatAmount = new Long("1000");
-        Long itemVatPercentage = new Long("1000");
+        Long itemAmount = 9000L;
+        Long itemVatAmount = 1000L;
+        Long itemVatPercentage = 1000L;
 
         List<InvoiceLine> invoiceLines = new ArrayList<>();
 

--- a/src/test/java/com/adyen/WebhookTest.java
+++ b/src/test/java/com/adyen/WebhookTest.java
@@ -137,7 +137,7 @@ public class WebhookTest extends BaseTest {
         assertEquals("9913333333333333", notificationRequestItem.getOriginalReference());
         assertNotNull(notificationRequestItem.getAmount());
         assertEquals("EUR", notificationRequestItem.getAmount().getCurrency());
-        assertEquals(new Long(1000), notificationRequestItem.getAmount().getValue());
+        assertEquals(Long.valueOf(1000), notificationRequestItem.getAmount().getValue());
 
         assertNotNull(notificationRequestItem.getEventDate());
     }
@@ -155,7 +155,7 @@ public class WebhookTest extends BaseTest {
         assertEquals("9913333333333333", notificationRequestItem.getOriginalReference());
         assertNotNull(notificationRequestItem.getAmount());
         assertEquals("EUR", notificationRequestItem.getAmount().getCurrency());
-        assertEquals(new Long(1000), notificationRequestItem.getAmount().getValue());
+        assertEquals(Long.valueOf(1000), notificationRequestItem.getAmount().getValue());
 
         assertNotNull(notificationRequestItem.getEventDate());
     }
@@ -173,7 +173,7 @@ public class WebhookTest extends BaseTest {
         assertEquals("8313547924770610", notificationRequestItem.getOriginalReference());
         assertNotNull(notificationRequestItem.getAmount());
         assertEquals("EUR", notificationRequestItem.getAmount().getCurrency());
-        assertEquals(new Long(500), notificationRequestItem.getAmount().getValue());
+        assertEquals(Long.valueOf(500), notificationRequestItem.getAmount().getValue());
 
         assertNotNull(notificationRequestItem.getEventDate());
     }


### PR DESCRIPTION
**Description**
Maven is not able to package with java 17 as library still used deprecated Long initializer and some minor other issues. This PR fixes that so everyone can package the library and test it using java 17. 
