### PR TITLE
Bring back from/toJson methods in oneOf and anyOf classes

### DIFF
--- a/src/main/java/com/adyen/model/checkout/CheckoutPaymentMethod.java
+++ b/src/main/java/com/adyen/model/checkout/CheckoutPaymentMethod.java
@@ -2186,5 +2186,24 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
         return (ZipDetails)super.getActualInstance();
     }
 
+    /**
+    * Create an instance of CheckoutPaymentMethod given an JSON string
+    *
+    * @param jsonString JSON string
+    * @return An instance of CheckoutPaymentMethod
+    * @throws IOException if the JSON string is invalid with respect to CheckoutPaymentMethod
+    */
+    public static CheckoutPaymentMethod fromJson(String jsonString) throws IOException {
+        return JSON.getMapper().readValue(jsonString, CheckoutPaymentMethod.class);
+    }
+
+    /**
+    * Convert an instance of CheckoutPaymentMethod to an JSON string
+    *
+    * @return JSON string
+    */
+    public String toJson() throws JsonProcessingException {
+        return JSON.getMapper().writeValueAsString(this);
+    }
 }
 

--- a/src/main/java/com/adyen/model/checkout/PaymentResponseAction.java
+++ b/src/main/java/com/adyen/model/checkout/PaymentResponseAction.java
@@ -578,5 +578,24 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
         return (CheckoutVoucherAction)super.getActualInstance();
     }
 
+    /**
+    * Create an instance of PaymentResponseAction given an JSON string
+    *
+    * @param jsonString JSON string
+    * @return An instance of PaymentResponseAction
+    * @throws IOException if the JSON string is invalid with respect to PaymentResponseAction
+    */
+    public static PaymentResponseAction fromJson(String jsonString) throws IOException {
+        return JSON.getMapper().readValue(jsonString, PaymentResponseAction.class);
+    }
+
+    /**
+    * Convert an instance of PaymentResponseAction to an JSON string
+    *
+    * @return JSON string
+    */
+    public String toJson() throws JsonProcessingException {
+        return JSON.getMapper().writeValueAsString(this);
+    }
 }
 

--- a/src/test/java/com/adyen/CheckoutTest.java
+++ b/src/test/java/com/adyen/CheckoutTest.java
@@ -435,4 +435,31 @@ public class CheckoutTest extends BaseTest {
                 queryParams
         );
     }
+
+    @Test
+    public void TestCheckoutPaymentMethodSerialisation() throws Exception {
+        CheckoutPaymentMethod checkoutPaymentMethodGoogle = CheckoutPaymentMethod.fromJson("{\n" +
+                "    \"type\": \"paywithgoogle\",\n" +
+                "    \"googlePayToken\": \"==Payload as retrieved from Google Pay response==\"\n" +
+                "  }");
+
+        CheckoutPaymentMethod checkoutPaymentMethodScheme = CheckoutPaymentMethod.fromJson("{\n" +
+                "    \"type\": \"scheme\",\n" +
+                "    \"number\": \"4111111111111111\",\n" +
+                "    \"cvc\": \"737\",\n" +
+                "    \"expiryMonth\": \"03\",\n" +
+                "    \"expiryYear\": \"2030\",\n" +
+                "    \"holderName\": \"John Smith\"\n" +
+                "  }");
+
+        CheckoutPaymentMethod checkoutPaymentMethodApple = CheckoutPaymentMethod.fromJson("{\n" +
+                "    \"type\": \"applepay\",\n" +
+                "    \"applePayToken\": \"VNRWtuNlNEWkRCSm1xWndjMDFFbktkQU...\"\n" +
+                "  }");
+
+        Assert.assertTrue(checkoutPaymentMethodGoogle.toJson().contains("paywithgoogle"));
+        Assert.assertTrue(checkoutPaymentMethodGoogle.toJson().contains("googlePayToken"));
+        Assert.assertTrue(checkoutPaymentMethodScheme.toJson().contains("scheme"));
+        Assert.assertTrue(checkoutPaymentMethodApple.toJson().contains("NRWtuNlNEWkRCSm1xWndjMDFFbktkQU"));
+    }
 }

--- a/templates/libraries/jersey3/anyof_model.mustache
+++ b/templates/libraries/jersey3/anyof_model.mustache
@@ -199,4 +199,23 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     {{/anyOf}}
+    /**
+    * Create an instance of {{classname}} given an JSON string
+    *
+    * @param jsonString JSON string
+    * @return An instance of {{classname}}
+    * @throws IOException if the JSON string is invalid with respect to {{classname}}
+    */
+    public static {{{classname}}} fromJson(String jsonString) throws IOException {
+        return JSON.getMapper().readValue(jsonString, {{{classname}}}.class);
+    }
+
+    /**
+    * Convert an instance of {{classname}} to an JSON string
+    *
+    * @return JSON string
+    */
+    public String toJson() throws JsonProcessingException {
+        return JSON.getMapper().writeValueAsString(this);
+    }
 }

--- a/templates/libraries/jersey3/oneof_model.mustache
+++ b/templates/libraries/jersey3/oneof_model.mustache
@@ -245,4 +245,23 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     {{/oneOf}}
+    /**
+    * Create an instance of {{classname}} given an JSON string
+    *
+    * @param jsonString JSON string
+    * @return An instance of {{classname}}
+    * @throws IOException if the JSON string is invalid with respect to {{classname}}
+    */
+    public static {{{classname}}} fromJson(String jsonString) throws IOException {
+        return JSON.getMapper().readValue(jsonString, {{{classname}}}.class);
+    }
+
+    /**
+    * Convert an instance of {{classname}} to an JSON string
+    *
+    * @return JSON string
+    */
+    public String toJson() throws JsonProcessingException {
+        return JSON.getMapper().writeValueAsString(this);
+    }
 }


### PR DESCRIPTION
**Description**
Bring back the from/toJson methods in oneOf/AnyOf classes. This was removed by accident as the jersey3 framework did not use these classes and it was added manually in the templates. Tested by generating checkout specs and adding UT for CheckoutPaymentMethod.
