### PR TITLE
Removed strict validation and regenerate oneOfs

### DIFF
--- a/src/main/java/com/adyen/model/balanceplatform/BankAccountIdentificationValidationRequestAccountIdentification.java
+++ b/src/main/java/com/adyen/model/balanceplatform/BankAccountIdentificationValidationRequestAccountIdentification.java
@@ -108,9 +108,6 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
             boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
             int match = 0;
             JsonToken token = tree.traverse(jp.getCodec()).nextToken();
-            // Local Object Mapper that forces strict validation
-            ObjectMapper localObjectMapper = JSON.getMapper();
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
             // deserialize AULocalAccountIdentification
             try {
@@ -129,7 +126,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(AULocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), AULocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), AULocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'AULocalAccountIdentification'");
@@ -157,7 +154,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(BRLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), BRLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), BRLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'BRLocalAccountIdentification'");
@@ -185,7 +182,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(CALocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CALocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CALocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CALocalAccountIdentification'");
@@ -213,7 +210,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(CZLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CZLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CZLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CZLocalAccountIdentification'");
@@ -241,7 +238,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(DKLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), DKLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), DKLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'DKLocalAccountIdentification'");
@@ -269,7 +266,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(HKLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), HKLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), HKLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'HKLocalAccountIdentification'");
@@ -297,7 +294,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(HULocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), HULocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), HULocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'HULocalAccountIdentification'");
@@ -325,7 +322,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(IbanAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), IbanAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), IbanAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'IbanAccountIdentification'");
@@ -353,7 +350,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(NOLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), NOLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), NOLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'NOLocalAccountIdentification'");
@@ -381,7 +378,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(NZLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), NZLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), NZLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'NZLocalAccountIdentification'");
@@ -409,7 +406,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(NumberAndBicAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), NumberAndBicAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), NumberAndBicAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'NumberAndBicAccountIdentification'");
@@ -437,7 +434,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(PLLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), PLLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), PLLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'PLLocalAccountIdentification'");
@@ -465,7 +462,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(SELocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), SELocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), SELocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'SELocalAccountIdentification'");
@@ -493,7 +490,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(SGLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), SGLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), SGLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'SGLocalAccountIdentification'");
@@ -521,7 +518,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(UKLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), UKLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), UKLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'UKLocalAccountIdentification'");
@@ -549,7 +546,7 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 boolean typeMatch = Arrays.stream(USLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), USLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), USLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'USLocalAccountIdentification'");
@@ -568,7 +565,6 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
                 log.log(Level.WARNING, String.format("Warning, indecisive deserialization for BankAccountIdentificationValidationRequestAccountIdentification: %d classes match result, expected 1", match));
             }
 
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             BankAccountIdentificationValidationRequestAccountIdentification ret = new BankAccountIdentificationValidationRequestAccountIdentification();
             ret.setActualInstance(deserialized);
             return ret;
@@ -991,5 +987,24 @@ public class BankAccountIdentificationValidationRequestAccountIdentification ext
         return (USLocalAccountIdentification)super.getActualInstance();
     }
 
+    /**
+    * Create an instance of BankAccountIdentificationValidationRequestAccountIdentification given an JSON string
+    *
+    * @param jsonString JSON string
+    * @return An instance of BankAccountIdentificationValidationRequestAccountIdentification
+    * @throws IOException if the JSON string is invalid with respect to BankAccountIdentificationValidationRequestAccountIdentification
+    */
+    public static BankAccountIdentificationValidationRequestAccountIdentification fromJson(String jsonString) throws IOException {
+        return JSON.getMapper().readValue(jsonString, BankAccountIdentificationValidationRequestAccountIdentification.class);
+    }
+
+    /**
+    * Convert an instance of BankAccountIdentificationValidationRequestAccountIdentification to an JSON string
+    *
+    * @return JSON string
+    */
+    public String toJson() throws JsonProcessingException {
+        return JSON.getMapper().writeValueAsString(this);
+    }
 }
 

--- a/src/main/java/com/adyen/model/balanceplatform/Card.java
+++ b/src/main/java/com/adyen/model/balanceplatform/Card.java
@@ -436,10 +436,10 @@ public class Card {
   }
 
    /**
-   * Allocates a specific product range for either a physical or a virtual card. Possible values: **fullySecure**, **secureCorporate**. &gt;Reach out to your Adyen contact to get the values relevant for your integration.
+   * Allocates a specific product range for either a physical or a virtual card. Possible values: **fullySupported**, **secureCorporate**. &gt;Reach out to your Adyen contact to get the values relevant for your integration.
    * @return threeDSecure
   **/
-  @ApiModelProperty(value = "Allocates a specific product range for either a physical or a virtual card. Possible values: **fullySecure**, **secureCorporate**. >Reach out to your Adyen contact to get the values relevant for your integration.")
+  @ApiModelProperty(value = "Allocates a specific product range for either a physical or a virtual card. Possible values: **fullySupported**, **secureCorporate**. >Reach out to your Adyen contact to get the values relevant for your integration.")
   @JsonProperty(JSON_PROPERTY_THREE_D_SECURE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 

--- a/src/main/java/com/adyen/model/balanceplatform/CardInfo.java
+++ b/src/main/java/com/adyen/model/balanceplatform/CardInfo.java
@@ -290,10 +290,10 @@ public class CardInfo {
   }
 
    /**
-   * Allocates a specific product range for either a physical or a virtual card. Possible values: **fullySecure**, **secureCorporate**. &gt;Reach out to your Adyen contact to get the values relevant for your integration.
+   * Allocates a specific product range for either a physical or a virtual card. Possible values: **fullySupported**, **secureCorporate**. &gt;Reach out to your Adyen contact to get the values relevant for your integration.
    * @return threeDSecure
   **/
-  @ApiModelProperty(value = "Allocates a specific product range for either a physical or a virtual card. Possible values: **fullySecure**, **secureCorporate**. >Reach out to your Adyen contact to get the values relevant for your integration.")
+  @ApiModelProperty(value = "Allocates a specific product range for either a physical or a virtual card. Possible values: **fullySupported**, **secureCorporate**. >Reach out to your Adyen contact to get the values relevant for your integration.")
   @JsonProperty(JSON_PROPERTY_THREE_D_SECURE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 

--- a/src/main/java/com/adyen/model/balanceplatform/PaymentInstrumentBankAccount.java
+++ b/src/main/java/com/adyen/model/balanceplatform/PaymentInstrumentBankAccount.java
@@ -93,9 +93,6 @@ public class PaymentInstrumentBankAccount extends AbstractOpenApiSchema {
             boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
             int match = 0;
             JsonToken token = tree.traverse(jp.getCodec()).nextToken();
-            // Local Object Mapper that forces strict validation
-            ObjectMapper localObjectMapper = JSON.getMapper();
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
             // deserialize IbanAccountIdentification
             try {
@@ -114,7 +111,7 @@ public class PaymentInstrumentBankAccount extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(IbanAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), IbanAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), IbanAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'IbanAccountIdentification'");
@@ -142,7 +139,7 @@ public class PaymentInstrumentBankAccount extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(USLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), USLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), USLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'USLocalAccountIdentification'");
@@ -161,7 +158,6 @@ public class PaymentInstrumentBankAccount extends AbstractOpenApiSchema {
                 log.log(Level.WARNING, String.format("Warning, indecisive deserialization for PaymentInstrumentBankAccount: %d classes match result, expected 1", match));
             }
 
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             PaymentInstrumentBankAccount ret = new PaymentInstrumentBankAccount();
             ret.setActualInstance(deserialized);
             return ret;
@@ -262,5 +258,24 @@ public class PaymentInstrumentBankAccount extends AbstractOpenApiSchema {
         return (USLocalAccountIdentification)super.getActualInstance();
     }
 
+    /**
+    * Create an instance of PaymentInstrumentBankAccount given an JSON string
+    *
+    * @param jsonString JSON string
+    * @return An instance of PaymentInstrumentBankAccount
+    * @throws IOException if the JSON string is invalid with respect to PaymentInstrumentBankAccount
+    */
+    public static PaymentInstrumentBankAccount fromJson(String jsonString) throws IOException {
+        return JSON.getMapper().readValue(jsonString, PaymentInstrumentBankAccount.class);
+    }
+
+    /**
+    * Convert an instance of PaymentInstrumentBankAccount to an JSON string
+    *
+    * @return JSON string
+    */
+    public String toJson() throws JsonProcessingException {
+        return JSON.getMapper().writeValueAsString(this);
+    }
 }
 

--- a/src/main/java/com/adyen/model/balanceplatform/UpdateSweepConfigurationV2.java
+++ b/src/main/java/com/adyen/model/balanceplatform/UpdateSweepConfigurationV2.java
@@ -36,7 +36,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
  * UpdateSweepConfigurationV2
  */
 @JsonPropertyOrder({
-  UpdateSweepConfigurationV2.JSON_PROPERTY_BALANCE_ACCOUNT_ID,
   UpdateSweepConfigurationV2.JSON_PROPERTY_CATEGORY,
   UpdateSweepConfigurationV2.JSON_PROPERTY_COUNTERPARTY,
   UpdateSweepConfigurationV2.JSON_PROPERTY_CURRENCY,
@@ -48,15 +47,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
   UpdateSweepConfigurationV2.JSON_PROPERTY_STATUS,
   UpdateSweepConfigurationV2.JSON_PROPERTY_SWEEP_AMOUNT,
   UpdateSweepConfigurationV2.JSON_PROPERTY_TARGET_AMOUNT,
-  UpdateSweepConfigurationV2.JSON_PROPERTY_TRANSFER_INSTRUMENT_ID,
   UpdateSweepConfigurationV2.JSON_PROPERTY_TRIGGER_AMOUNT,
   UpdateSweepConfigurationV2.JSON_PROPERTY_TYPE
 })
 
 public class UpdateSweepConfigurationV2 {
-  public static final String JSON_PROPERTY_BALANCE_ACCOUNT_ID = "balanceAccountId";
-  private String balanceAccountId;
-
   /**
    * The type of transfer that results from the sweep.  Possible values:   - **bank**: Sweep to a [transfer instrument](https://docs.adyen.com/api-explorer/#/legalentity/latest/post/transferInstruments__resParam_id).  - **internal**: Transfer to another [balance account](https://docs.adyen.com/api-explorer/#/balanceplatform/latest/post/balanceAccounts__resParam_id) within your platform.  Required when setting &#x60;priorities&#x60;.
    */
@@ -264,9 +259,6 @@ public class UpdateSweepConfigurationV2 {
   public static final String JSON_PROPERTY_TARGET_AMOUNT = "targetAmount";
   private Amount targetAmount;
 
-  public static final String JSON_PROPERTY_TRANSFER_INSTRUMENT_ID = "transferInstrumentId";
-  private String transferInstrumentId;
-
   public static final String JSON_PROPERTY_TRIGGER_AMOUNT = "triggerAmount";
   private Amount triggerAmount;
 
@@ -310,31 +302,6 @@ public class UpdateSweepConfigurationV2 {
 
   public UpdateSweepConfigurationV2() { 
   }
-
-  public UpdateSweepConfigurationV2 balanceAccountId(String balanceAccountId) {
-    this.balanceAccountId = balanceAccountId;
-    return this;
-  }
-
-   /**
-   * The unique identifier of the destination or source [balance account](https://docs.adyen.com/api-explorer/#/balanceplatform/latest/post/balanceAccounts__resParam_id).   You can only use this for periodic sweep schedules such as &#x60;schedule.type&#x60; **daily** or **monthly**.
-   * @return balanceAccountId
-  **/
-  @ApiModelProperty(value = "The unique identifier of the destination or source [balance account](https://docs.adyen.com/api-explorer/#/balanceplatform/latest/post/balanceAccounts__resParam_id).   You can only use this for periodic sweep schedules such as `schedule.type` **daily** or **monthly**.")
-  @JsonProperty(JSON_PROPERTY_BALANCE_ACCOUNT_ID)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public String getBalanceAccountId() {
-    return balanceAccountId;
-  }
-
-
-  @JsonProperty(JSON_PROPERTY_BALANCE_ACCOUNT_ID)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setBalanceAccountId(String balanceAccountId) {
-    this.balanceAccountId = balanceAccountId;
-  }
-
 
   public UpdateSweepConfigurationV2 category(CategoryEnum category) {
     this.category = category;
@@ -619,31 +586,6 @@ public class UpdateSweepConfigurationV2 {
   }
 
 
-  public UpdateSweepConfigurationV2 transferInstrumentId(String transferInstrumentId) {
-    this.transferInstrumentId = transferInstrumentId;
-    return this;
-  }
-
-   /**
-   * The unique identifier of the destination or source [transfer instrument](https://docs.adyen.com/api-explorer/#/balanceplatform/latest/post/transferInstruments__resParam_id).  You can also use this in combination with a &#x60;merchantAccount&#x60; and a &#x60;type&#x60; **pull** to start a direct debit request from the source transfer instrument. To use this feature, reach out to your Adyen contact.
-   * @return transferInstrumentId
-  **/
-  @ApiModelProperty(value = "The unique identifier of the destination or source [transfer instrument](https://docs.adyen.com/api-explorer/#/balanceplatform/latest/post/transferInstruments__resParam_id).  You can also use this in combination with a `merchantAccount` and a `type` **pull** to start a direct debit request from the source transfer instrument. To use this feature, reach out to your Adyen contact.")
-  @JsonProperty(JSON_PROPERTY_TRANSFER_INSTRUMENT_ID)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public String getTransferInstrumentId() {
-    return transferInstrumentId;
-  }
-
-
-  @JsonProperty(JSON_PROPERTY_TRANSFER_INSTRUMENT_ID)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setTransferInstrumentId(String transferInstrumentId) {
-    this.transferInstrumentId = transferInstrumentId;
-  }
-
-
   public UpdateSweepConfigurationV2 triggerAmount(Amount triggerAmount) {
     this.triggerAmount = triggerAmount;
     return this;
@@ -706,8 +648,7 @@ public class UpdateSweepConfigurationV2 {
       return false;
     }
     UpdateSweepConfigurationV2 updateSweepConfigurationV2 = (UpdateSweepConfigurationV2) o;
-    return Objects.equals(this.balanceAccountId, updateSweepConfigurationV2.balanceAccountId) &&
-        Objects.equals(this.category, updateSweepConfigurationV2.category) &&
+    return Objects.equals(this.category, updateSweepConfigurationV2.category) &&
         Objects.equals(this.counterparty, updateSweepConfigurationV2.counterparty) &&
         Objects.equals(this.currency, updateSweepConfigurationV2.currency) &&
         Objects.equals(this.description, updateSweepConfigurationV2.description) &&
@@ -718,21 +659,19 @@ public class UpdateSweepConfigurationV2 {
         Objects.equals(this.status, updateSweepConfigurationV2.status) &&
         Objects.equals(this.sweepAmount, updateSweepConfigurationV2.sweepAmount) &&
         Objects.equals(this.targetAmount, updateSweepConfigurationV2.targetAmount) &&
-        Objects.equals(this.transferInstrumentId, updateSweepConfigurationV2.transferInstrumentId) &&
         Objects.equals(this.triggerAmount, updateSweepConfigurationV2.triggerAmount) &&
         Objects.equals(this.type, updateSweepConfigurationV2.type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(balanceAccountId, category, counterparty, currency, description, id, priorities, reason, schedule, status, sweepAmount, targetAmount, transferInstrumentId, triggerAmount, type);
+    return Objects.hash(category, counterparty, currency, description, id, priorities, reason, schedule, status, sweepAmount, targetAmount, triggerAmount, type);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class UpdateSweepConfigurationV2 {\n");
-    sb.append("    balanceAccountId: ").append(toIndentedString(balanceAccountId)).append("\n");
     sb.append("    category: ").append(toIndentedString(category)).append("\n");
     sb.append("    counterparty: ").append(toIndentedString(counterparty)).append("\n");
     sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
@@ -744,7 +683,6 @@ public class UpdateSweepConfigurationV2 {
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    sweepAmount: ").append(toIndentedString(sweepAmount)).append("\n");
     sb.append("    targetAmount: ").append(toIndentedString(targetAmount)).append("\n");
-    sb.append("    transferInstrumentId: ").append(toIndentedString(transferInstrumentId)).append("\n");
     sb.append("    triggerAmount: ").append(toIndentedString(triggerAmount)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("}");

--- a/src/main/java/com/adyen/model/balanceplatform/VerificationDeadline.java
+++ b/src/main/java/com/adyen/model/balanceplatform/VerificationDeadline.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
  */
 @JsonPropertyOrder({
   VerificationDeadline.JSON_PROPERTY_CAPABILITIES,
+  VerificationDeadline.JSON_PROPERTY_ENTITY_IDS,
   VerificationDeadline.JSON_PROPERTY_EXPIRES_AT
 })
 
@@ -173,6 +174,9 @@ public class VerificationDeadline {
   public static final String JSON_PROPERTY_CAPABILITIES = "capabilities";
   private List<CapabilitiesEnum> capabilities = new ArrayList<>();
 
+  public static final String JSON_PROPERTY_ENTITY_IDS = "entityIds";
+  private List<String> entityIds = null;
+
   public static final String JSON_PROPERTY_EXPIRES_AT = "expiresAt";
   private OffsetDateTime expiresAt;
 
@@ -206,6 +210,39 @@ public class VerificationDeadline {
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapabilities(List<CapabilitiesEnum> capabilities) {
     this.capabilities = capabilities;
+  }
+
+
+  public VerificationDeadline entityIds(List<String> entityIds) {
+    this.entityIds = entityIds;
+    return this;
+  }
+
+  public VerificationDeadline addEntityIdsItem(String entityIdsItem) {
+    if (this.entityIds == null) {
+      this.entityIds = new ArrayList<>();
+    }
+    this.entityIds.add(entityIdsItem);
+    return this;
+  }
+
+   /**
+   * The unique identifiers of the bank account(s) that the deadline applies to
+   * @return entityIds
+  **/
+  @ApiModelProperty(value = "The unique identifiers of the bank account(s) that the deadline applies to")
+  @JsonProperty(JSON_PROPERTY_ENTITY_IDS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public List<String> getEntityIds() {
+    return entityIds;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_ENTITY_IDS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setEntityIds(List<String> entityIds) {
+    this.entityIds = entityIds;
   }
 
 
@@ -247,12 +284,13 @@ public class VerificationDeadline {
     }
     VerificationDeadline verificationDeadline = (VerificationDeadline) o;
     return Objects.equals(this.capabilities, verificationDeadline.capabilities) &&
+        Objects.equals(this.entityIds, verificationDeadline.entityIds) &&
         Objects.equals(this.expiresAt, verificationDeadline.expiresAt);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(capabilities, expiresAt);
+    return Objects.hash(capabilities, entityIds, expiresAt);
   }
 
   @Override
@@ -260,6 +298,7 @@ public class VerificationDeadline {
     StringBuilder sb = new StringBuilder();
     sb.append("class VerificationDeadline {\n");
     sb.append("    capabilities: ").append(toIndentedString(capabilities)).append("\n");
+    sb.append("    entityIds: ").append(toIndentedString(entityIds)).append("\n");
     sb.append("    expiresAt: ").append(toIndentedString(expiresAt)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/src/main/java/com/adyen/model/checkout/CheckoutPaymentMethod.java
+++ b/src/main/java/com/adyen/model/checkout/CheckoutPaymentMethod.java
@@ -130,9 +130,6 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
             boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
             int match = 0;
             JsonToken token = tree.traverse(jp.getCodec()).nextToken();
-            // Local Object Mapper that forces strict validation
-            ObjectMapper localObjectMapper = JSON.getMapper();
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
             // deserialize AchDetails
             try {
@@ -151,7 +148,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(AchDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), AchDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), AchDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'AchDetails'");
@@ -179,7 +176,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(AfterpayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), AfterpayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), AfterpayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'AfterpayDetails'");
@@ -207,7 +204,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(AmazonPayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), AmazonPayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), AmazonPayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'AmazonPayDetails'");
@@ -235,7 +232,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(AndroidPayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), AndroidPayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), AndroidPayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'AndroidPayDetails'");
@@ -263,7 +260,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(ApplePayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), ApplePayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), ApplePayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'ApplePayDetails'");
@@ -291,7 +288,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(BacsDirectDebitDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), BacsDirectDebitDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), BacsDirectDebitDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'BacsDirectDebitDetails'");
@@ -319,7 +316,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(BillDeskDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), BillDeskDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), BillDeskDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'BillDeskDetails'");
@@ -347,7 +344,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(BlikDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), BlikDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), BlikDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'BlikDetails'");
@@ -375,7 +372,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CardDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CardDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CardDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CardDetails'");
@@ -403,7 +400,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CellulantDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CellulantDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CellulantDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CellulantDetails'");
@@ -431,7 +428,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(DokuDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), DokuDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), DokuDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'DokuDetails'");
@@ -459,7 +456,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(DotpayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), DotpayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), DotpayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'DotpayDetails'");
@@ -487,7 +484,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(DragonpayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), DragonpayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), DragonpayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'DragonpayDetails'");
@@ -515,7 +512,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(EcontextVoucherDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), EcontextVoucherDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), EcontextVoucherDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'EcontextVoucherDetails'");
@@ -543,7 +540,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(GenericIssuerPaymentMethodDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), GenericIssuerPaymentMethodDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), GenericIssuerPaymentMethodDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'GenericIssuerPaymentMethodDetails'");
@@ -571,7 +568,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(GiropayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), GiropayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), GiropayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'GiropayDetails'");
@@ -599,7 +596,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(GooglePayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), GooglePayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), GooglePayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'GooglePayDetails'");
@@ -627,7 +624,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(IdealDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), IdealDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), IdealDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'IdealDetails'");
@@ -655,7 +652,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(KlarnaDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), KlarnaDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), KlarnaDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'KlarnaDetails'");
@@ -683,7 +680,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(MasterpassDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), MasterpassDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), MasterpassDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'MasterpassDetails'");
@@ -711,7 +708,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(MbwayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), MbwayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), MbwayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'MbwayDetails'");
@@ -739,7 +736,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(MobilePayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), MobilePayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), MobilePayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'MobilePayDetails'");
@@ -767,7 +764,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(MolPayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), MolPayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), MolPayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'MolPayDetails'");
@@ -795,7 +792,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(OpenInvoiceDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), OpenInvoiceDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), OpenInvoiceDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'OpenInvoiceDetails'");
@@ -823,7 +820,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(PayPalDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), PayPalDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), PayPalDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'PayPalDetails'");
@@ -851,7 +848,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(PayUUpiDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), PayUUpiDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), PayUUpiDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'PayUUpiDetails'");
@@ -879,7 +876,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(PayWithGoogleDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), PayWithGoogleDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), PayWithGoogleDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'PayWithGoogleDetails'");
@@ -907,7 +904,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(PaymentDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), PaymentDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), PaymentDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'PaymentDetails'");
@@ -935,7 +932,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(RatepayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), RatepayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), RatepayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'RatepayDetails'");
@@ -963,7 +960,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(SamsungPayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), SamsungPayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), SamsungPayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'SamsungPayDetails'");
@@ -991,7 +988,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(SepaDirectDebitDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), SepaDirectDebitDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), SepaDirectDebitDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'SepaDirectDebitDetails'");
@@ -1019,7 +1016,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(StoredPaymentMethodDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), StoredPaymentMethodDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), StoredPaymentMethodDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'StoredPaymentMethodDetails'");
@@ -1047,7 +1044,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(UpiCollectDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), UpiCollectDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), UpiCollectDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'UpiCollectDetails'");
@@ -1075,7 +1072,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(UpiIntentDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), UpiIntentDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), UpiIntentDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'UpiIntentDetails'");
@@ -1103,7 +1100,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(VippsDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), VippsDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), VippsDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'VippsDetails'");
@@ -1131,7 +1128,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(VisaCheckoutDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), VisaCheckoutDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), VisaCheckoutDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'VisaCheckoutDetails'");
@@ -1159,7 +1156,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(WeChatPayDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), WeChatPayDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), WeChatPayDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'WeChatPayDetails'");
@@ -1187,7 +1184,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(WeChatPayMiniProgramDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), WeChatPayMiniProgramDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), WeChatPayMiniProgramDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'WeChatPayMiniProgramDetails'");
@@ -1215,7 +1212,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(ZipDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), ZipDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), ZipDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'ZipDetails'");
@@ -1234,7 +1231,6 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
                 log.log(Level.WARNING, String.format("Warning, indecisive deserialization for CheckoutPaymentMethod: %d classes match result, expected 1", match));
             }
 
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             CheckoutPaymentMethod ret = new CheckoutPaymentMethod();
             ret.setActualInstance(deserialized);
             return ret;

--- a/src/main/java/com/adyen/model/checkout/PaymentResponseAction.java
+++ b/src/main/java/com/adyen/model/checkout/PaymentResponseAction.java
@@ -103,9 +103,6 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
             boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
             int match = 0;
             JsonToken token = tree.traverse(jp.getCodec()).nextToken();
-            // Local Object Mapper that forces strict validation
-            ObjectMapper localObjectMapper = JSON.getMapper();
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
             // deserialize CheckoutAwaitAction
             try {
@@ -124,7 +121,7 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CheckoutAwaitAction.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CheckoutAwaitAction.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CheckoutAwaitAction.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CheckoutAwaitAction'");
@@ -152,7 +149,7 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CheckoutDelegatedAuthenticationAction.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CheckoutDelegatedAuthenticationAction.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CheckoutDelegatedAuthenticationAction.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CheckoutDelegatedAuthenticationAction'");
@@ -180,7 +177,7 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CheckoutNativeRedirectAction.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CheckoutNativeRedirectAction.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CheckoutNativeRedirectAction.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CheckoutNativeRedirectAction'");
@@ -208,7 +205,7 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CheckoutQrCodeAction.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CheckoutQrCodeAction.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CheckoutQrCodeAction.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CheckoutQrCodeAction'");
@@ -236,7 +233,7 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CheckoutRedirectAction.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CheckoutRedirectAction.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CheckoutRedirectAction.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CheckoutRedirectAction'");
@@ -264,7 +261,7 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CheckoutSDKAction.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CheckoutSDKAction.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CheckoutSDKAction.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CheckoutSDKAction'");
@@ -292,7 +289,7 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CheckoutThreeDS2Action.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CheckoutThreeDS2Action.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CheckoutThreeDS2Action.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CheckoutThreeDS2Action'");
@@ -320,7 +317,7 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CheckoutVoucherAction.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CheckoutVoucherAction.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CheckoutVoucherAction.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CheckoutVoucherAction'");
@@ -339,7 +336,6 @@ public class PaymentResponseAction extends AbstractOpenApiSchema {
                 log.log(Level.WARNING, String.format("Warning, indecisive deserialization for PaymentResponseAction: %d classes match result, expected 1", match));
             }
 
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             PaymentResponseAction ret = new PaymentResponseAction();
             ret.setActualInstance(deserialized);
             return ret;

--- a/src/main/java/com/adyen/model/legalentitymanagement/BankAccountInfoAccountIdentification.java
+++ b/src/main/java/com/adyen/model/legalentitymanagement/BankAccountInfoAccountIdentification.java
@@ -105,9 +105,6 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
             boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
             int match = 0;
             JsonToken token = tree.traverse(jp.getCodec()).nextToken();
-            // Local Object Mapper that forces strict validation
-            ObjectMapper localObjectMapper = JSON.getMapper();
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
             // deserialize AULocalAccountIdentification
             try {
@@ -126,7 +123,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(AULocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), AULocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), AULocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'AULocalAccountIdentification'");
@@ -154,7 +151,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(CALocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CALocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CALocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CALocalAccountIdentification'");
@@ -182,7 +179,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(CZLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CZLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CZLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CZLocalAccountIdentification'");
@@ -210,7 +207,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(DKLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), DKLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), DKLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'DKLocalAccountIdentification'");
@@ -238,7 +235,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(HULocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), HULocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), HULocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'HULocalAccountIdentification'");
@@ -266,7 +263,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(IbanAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), IbanAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), IbanAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'IbanAccountIdentification'");
@@ -294,7 +291,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(NOLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), NOLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), NOLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'NOLocalAccountIdentification'");
@@ -322,7 +319,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(NumberAndBicAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), NumberAndBicAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), NumberAndBicAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'NumberAndBicAccountIdentification'");
@@ -350,7 +347,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(PLLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), PLLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), PLLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'PLLocalAccountIdentification'");
@@ -378,7 +375,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(SELocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), SELocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), SELocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'SELocalAccountIdentification'");
@@ -406,7 +403,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(SGLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), SGLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), SGLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'SGLocalAccountIdentification'");
@@ -434,7 +431,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(UKLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), UKLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), UKLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'UKLocalAccountIdentification'");
@@ -462,7 +459,7 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 boolean typeMatch = Arrays.stream(USLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), USLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), USLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'USLocalAccountIdentification'");
@@ -481,7 +478,6 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
                 log.log(Level.WARNING, String.format("Warning, indecisive deserialization for BankAccountInfoAccountIdentification: %d classes match result, expected 1", match));
             }
 
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             BankAccountInfoAccountIdentification ret = new BankAccountInfoAccountIdentification();
             ret.setActualInstance(deserialized);
             return ret;
@@ -835,5 +831,24 @@ public class BankAccountInfoAccountIdentification extends AbstractOpenApiSchema 
         return (USLocalAccountIdentification)super.getActualInstance();
     }
 
+    /**
+    * Create an instance of BankAccountInfoAccountIdentification given an JSON string
+    *
+    * @param jsonString JSON string
+    * @return An instance of BankAccountInfoAccountIdentification
+    * @throws IOException if the JSON string is invalid with respect to BankAccountInfoAccountIdentification
+    */
+    public static BankAccountInfoAccountIdentification fromJson(String jsonString) throws IOException {
+        return JSON.getMapper().readValue(jsonString, BankAccountInfoAccountIdentification.class);
+    }
+
+    /**
+    * Convert an instance of BankAccountInfoAccountIdentification to an JSON string
+    *
+    * @return JSON string
+    */
+    public String toJson() throws JsonProcessingException {
+        return JSON.getMapper().writeValueAsString(this);
+    }
 }
 

--- a/src/main/java/com/adyen/model/management/ScheduleTerminalActionsRequestActionDetails.java
+++ b/src/main/java/com/adyen/model/management/ScheduleTerminalActionsRequestActionDetails.java
@@ -96,9 +96,6 @@ public class ScheduleTerminalActionsRequestActionDetails extends AbstractOpenApi
             boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
             int match = 0;
             JsonToken token = tree.traverse(jp.getCodec()).nextToken();
-            // Local Object Mapper that forces strict validation
-            ObjectMapper localObjectMapper = JSON.getMapper();
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
             // deserialize InstallAndroidAppDetails
             try {
@@ -117,7 +114,7 @@ public class ScheduleTerminalActionsRequestActionDetails extends AbstractOpenApi
                 boolean typeMatch = Arrays.stream(InstallAndroidAppDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), InstallAndroidAppDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), InstallAndroidAppDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'InstallAndroidAppDetails'");
@@ -145,7 +142,7 @@ public class ScheduleTerminalActionsRequestActionDetails extends AbstractOpenApi
                 boolean typeMatch = Arrays.stream(InstallAndroidCertificateDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), InstallAndroidCertificateDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), InstallAndroidCertificateDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'InstallAndroidCertificateDetails'");
@@ -173,7 +170,7 @@ public class ScheduleTerminalActionsRequestActionDetails extends AbstractOpenApi
                 boolean typeMatch = Arrays.stream(ReleaseUpdateDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), ReleaseUpdateDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), ReleaseUpdateDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'ReleaseUpdateDetails'");
@@ -201,7 +198,7 @@ public class ScheduleTerminalActionsRequestActionDetails extends AbstractOpenApi
                 boolean typeMatch = Arrays.stream(UninstallAndroidAppDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), UninstallAndroidAppDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), UninstallAndroidAppDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'UninstallAndroidAppDetails'");
@@ -229,7 +226,7 @@ public class ScheduleTerminalActionsRequestActionDetails extends AbstractOpenApi
                 boolean typeMatch = Arrays.stream(UninstallAndroidCertificateDetails.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), UninstallAndroidCertificateDetails.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), UninstallAndroidCertificateDetails.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'UninstallAndroidCertificateDetails'");
@@ -248,7 +245,6 @@ public class ScheduleTerminalActionsRequestActionDetails extends AbstractOpenApi
                 log.log(Level.WARNING, String.format("Warning, indecisive deserialization for ScheduleTerminalActionsRequestActionDetails: %d classes match result, expected 1", match));
             }
 
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             ScheduleTerminalActionsRequestActionDetails ret = new ScheduleTerminalActionsRequestActionDetails();
             ret.setActualInstance(deserialized);
             return ret;
@@ -418,5 +414,24 @@ public class ScheduleTerminalActionsRequestActionDetails extends AbstractOpenApi
         return (UninstallAndroidCertificateDetails)super.getActualInstance();
     }
 
+    /**
+    * Create an instance of ScheduleTerminalActionsRequestActionDetails given an JSON string
+    *
+    * @param jsonString JSON string
+    * @return An instance of ScheduleTerminalActionsRequestActionDetails
+    * @throws IOException if the JSON string is invalid with respect to ScheduleTerminalActionsRequestActionDetails
+    */
+    public static ScheduleTerminalActionsRequestActionDetails fromJson(String jsonString) throws IOException {
+        return JSON.getMapper().readValue(jsonString, ScheduleTerminalActionsRequestActionDetails.class);
+    }
+
+    /**
+    * Convert an instance of ScheduleTerminalActionsRequestActionDetails to an JSON string
+    *
+    * @return JSON string
+    */
+    public String toJson() throws JsonProcessingException {
+        return JSON.getMapper().writeValueAsString(this);
+    }
 }
 

--- a/src/main/java/com/adyen/model/transfers/BankAccountV3AccountIdentification.java
+++ b/src/main/java/com/adyen/model/transfers/BankAccountV3AccountIdentification.java
@@ -22,6 +22,7 @@ import com.adyen.model.transfers.BRLocalAccountIdentification;
 import com.adyen.model.transfers.CALocalAccountIdentification;
 import com.adyen.model.transfers.CZLocalAccountIdentification;
 import com.adyen.model.transfers.DKLocalAccountIdentification;
+import com.adyen.model.transfers.HKLocalAccountIdentification;
 import com.adyen.model.transfers.HULocalAccountIdentification;
 import com.adyen.model.transfers.IbanAccountIdentification;
 import com.adyen.model.transfers.NOLocalAccountIdentification;
@@ -107,9 +108,6 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
             boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
             int match = 0;
             JsonToken token = tree.traverse(jp.getCodec()).nextToken();
-            // Local Object Mapper that forces strict validation
-            ObjectMapper localObjectMapper = JSON.getMapper();
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
             // deserialize AULocalAccountIdentification
             try {
@@ -128,7 +126,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(AULocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), AULocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), AULocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'AULocalAccountIdentification'");
@@ -156,7 +154,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(BRLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), BRLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), BRLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'BRLocalAccountIdentification'");
@@ -184,7 +182,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CALocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CALocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CALocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CALocalAccountIdentification'");
@@ -212,7 +210,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(CZLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), CZLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), CZLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'CZLocalAccountIdentification'");
@@ -240,7 +238,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(DKLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), DKLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), DKLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'DKLocalAccountIdentification'");
@@ -248,6 +246,34 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
             } catch (Exception e) {
                 // deserialization failed, continue
                 log.log(Level.FINER, "Input data does not match schema 'DKLocalAccountIdentification'", e);
+            }
+
+
+            // deserialize HKLocalAccountIdentification
+            try {
+                boolean attemptParsing = true;
+                // ensure that we respect type coercion as set on the client ObjectMapper
+                if (HKLocalAccountIdentification.class.equals(Integer.class) || HKLocalAccountIdentification.class.equals(Long.class) || HKLocalAccountIdentification.class.equals(Float.class) || HKLocalAccountIdentification.class.equals(Double.class) || HKLocalAccountIdentification.class.equals(Boolean.class) || HKLocalAccountIdentification.class.equals(String.class)) {
+                    attemptParsing = typeCoercion;
+                    if (!attemptParsing) {
+                        attemptParsing |= ((HKLocalAccountIdentification.class.equals(Integer.class) || HKLocalAccountIdentification.class.equals(Long.class)) && token == JsonToken.VALUE_NUMBER_INT);
+                        attemptParsing |= ((HKLocalAccountIdentification.class.equals(Float.class) || HKLocalAccountIdentification.class.equals(Double.class)) && token == JsonToken.VALUE_NUMBER_FLOAT);
+                        attemptParsing |= (HKLocalAccountIdentification.class.equals(Boolean.class) && (token == JsonToken.VALUE_FALSE || token == JsonToken.VALUE_TRUE));
+                        attemptParsing |= (HKLocalAccountIdentification.class.equals(String.class) && token == JsonToken.VALUE_STRING);
+                    }
+                }
+                // Checks if the unique type of the oneOf json matches any of the object TypeEnum values
+                boolean typeMatch = Arrays.stream(HKLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
+                if (attemptParsing || typeMatch) {
+                    // Strict deserialization for oneOf models
+                    deserialized = JSON.getMapper().readValue(tree.toString(), HKLocalAccountIdentification.class);
+                    // typeMatch should enforce proper deserialization
+                    match++;
+                    log.log(Level.FINER, "Input data matches schema 'HKLocalAccountIdentification'");
+                }
+            } catch (Exception e) {
+                // deserialization failed, continue
+                log.log(Level.FINER, "Input data does not match schema 'HKLocalAccountIdentification'", e);
             }
 
 
@@ -268,7 +294,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(HULocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), HULocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), HULocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'HULocalAccountIdentification'");
@@ -296,7 +322,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(IbanAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), IbanAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), IbanAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'IbanAccountIdentification'");
@@ -324,7 +350,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(NOLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), NOLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), NOLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'NOLocalAccountIdentification'");
@@ -352,7 +378,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(NZLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), NZLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), NZLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'NZLocalAccountIdentification'");
@@ -380,7 +406,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(NumberAndBicAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), NumberAndBicAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), NumberAndBicAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'NumberAndBicAccountIdentification'");
@@ -408,7 +434,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(PLLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), PLLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), PLLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'PLLocalAccountIdentification'");
@@ -436,7 +462,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(SELocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), SELocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), SELocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'SELocalAccountIdentification'");
@@ -464,7 +490,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(SGLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), SGLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), SGLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'SGLocalAccountIdentification'");
@@ -492,7 +518,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(UKLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), UKLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), UKLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'UKLocalAccountIdentification'");
@@ -520,7 +546,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 boolean typeMatch = Arrays.stream(USLocalAccountIdentification.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), USLocalAccountIdentification.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), USLocalAccountIdentification.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema 'USLocalAccountIdentification'");
@@ -539,7 +565,6 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
                 log.log(Level.WARNING, String.format("Warning, indecisive deserialization for BankAccountV3AccountIdentification: %d classes match result, expected 1", match));
             }
 
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             BankAccountV3AccountIdentification ret = new BankAccountV3AccountIdentification();
             ret.setActualInstance(deserialized);
             return ret;
@@ -582,6 +607,11 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
     }
 
     public BankAccountV3AccountIdentification(DKLocalAccountIdentification o) {
+        super("oneOf", Boolean.FALSE);
+        setActualInstance(o);
+    }
+
+    public BankAccountV3AccountIdentification(HKLocalAccountIdentification o) {
         super("oneOf", Boolean.FALSE);
         setActualInstance(o);
     }
@@ -647,6 +677,8 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
         });
         schemas.put("DKLocalAccountIdentification", new GenericType<DKLocalAccountIdentification>() {
         });
+        schemas.put("HKLocalAccountIdentification", new GenericType<HKLocalAccountIdentification>() {
+        });
         schemas.put("HULocalAccountIdentification", new GenericType<HULocalAccountIdentification>() {
         });
         schemas.put("IbanAccountIdentification", new GenericType<IbanAccountIdentification>() {
@@ -678,7 +710,7 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
     /**
      * Set the instance that matches the oneOf child schema, check
      * the instance parameter is valid against the oneOf child schemas:
-     * AULocalAccountIdentification, BRLocalAccountIdentification, CALocalAccountIdentification, CZLocalAccountIdentification, DKLocalAccountIdentification, HULocalAccountIdentification, IbanAccountIdentification, NOLocalAccountIdentification, NZLocalAccountIdentification, NumberAndBicAccountIdentification, PLLocalAccountIdentification, SELocalAccountIdentification, SGLocalAccountIdentification, UKLocalAccountIdentification, USLocalAccountIdentification
+     * AULocalAccountIdentification, BRLocalAccountIdentification, CALocalAccountIdentification, CZLocalAccountIdentification, DKLocalAccountIdentification, HKLocalAccountIdentification, HULocalAccountIdentification, IbanAccountIdentification, NOLocalAccountIdentification, NZLocalAccountIdentification, NumberAndBicAccountIdentification, PLLocalAccountIdentification, SELocalAccountIdentification, SGLocalAccountIdentification, UKLocalAccountIdentification, USLocalAccountIdentification
      *
      * It could be an instance of the 'oneOf' schemas.
      * The oneOf child schemas may themselves be a composed schema (allOf, anyOf, oneOf).
@@ -706,6 +738,11 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
         }
 
         if (JSON.isInstanceOf(DKLocalAccountIdentification.class, instance, new HashSet<Class<?>>())) {
+            super.setActualInstance(instance);
+            return;
+        }
+
+        if (JSON.isInstanceOf(HKLocalAccountIdentification.class, instance, new HashSet<Class<?>>())) {
             super.setActualInstance(instance);
             return;
         }
@@ -760,14 +797,14 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
             return;
         }
 
-        throw new RuntimeException("Invalid instance type. Must be AULocalAccountIdentification, BRLocalAccountIdentification, CALocalAccountIdentification, CZLocalAccountIdentification, DKLocalAccountIdentification, HULocalAccountIdentification, IbanAccountIdentification, NOLocalAccountIdentification, NZLocalAccountIdentification, NumberAndBicAccountIdentification, PLLocalAccountIdentification, SELocalAccountIdentification, SGLocalAccountIdentification, UKLocalAccountIdentification, USLocalAccountIdentification");
+        throw new RuntimeException("Invalid instance type. Must be AULocalAccountIdentification, BRLocalAccountIdentification, CALocalAccountIdentification, CZLocalAccountIdentification, DKLocalAccountIdentification, HKLocalAccountIdentification, HULocalAccountIdentification, IbanAccountIdentification, NOLocalAccountIdentification, NZLocalAccountIdentification, NumberAndBicAccountIdentification, PLLocalAccountIdentification, SELocalAccountIdentification, SGLocalAccountIdentification, UKLocalAccountIdentification, USLocalAccountIdentification");
     }
 
     /**
      * Get the actual instance, which can be the following:
-     * AULocalAccountIdentification, BRLocalAccountIdentification, CALocalAccountIdentification, CZLocalAccountIdentification, DKLocalAccountIdentification, HULocalAccountIdentification, IbanAccountIdentification, NOLocalAccountIdentification, NZLocalAccountIdentification, NumberAndBicAccountIdentification, PLLocalAccountIdentification, SELocalAccountIdentification, SGLocalAccountIdentification, UKLocalAccountIdentification, USLocalAccountIdentification
+     * AULocalAccountIdentification, BRLocalAccountIdentification, CALocalAccountIdentification, CZLocalAccountIdentification, DKLocalAccountIdentification, HKLocalAccountIdentification, HULocalAccountIdentification, IbanAccountIdentification, NOLocalAccountIdentification, NZLocalAccountIdentification, NumberAndBicAccountIdentification, PLLocalAccountIdentification, SELocalAccountIdentification, SGLocalAccountIdentification, UKLocalAccountIdentification, USLocalAccountIdentification
      *
-     * @return The actual instance (AULocalAccountIdentification, BRLocalAccountIdentification, CALocalAccountIdentification, CZLocalAccountIdentification, DKLocalAccountIdentification, HULocalAccountIdentification, IbanAccountIdentification, NOLocalAccountIdentification, NZLocalAccountIdentification, NumberAndBicAccountIdentification, PLLocalAccountIdentification, SELocalAccountIdentification, SGLocalAccountIdentification, UKLocalAccountIdentification, USLocalAccountIdentification)
+     * @return The actual instance (AULocalAccountIdentification, BRLocalAccountIdentification, CALocalAccountIdentification, CZLocalAccountIdentification, DKLocalAccountIdentification, HKLocalAccountIdentification, HULocalAccountIdentification, IbanAccountIdentification, NOLocalAccountIdentification, NZLocalAccountIdentification, NumberAndBicAccountIdentification, PLLocalAccountIdentification, SELocalAccountIdentification, SGLocalAccountIdentification, UKLocalAccountIdentification, USLocalAccountIdentification)
      */
     @Override
     public Object getActualInstance() {
@@ -827,6 +864,17 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
      */
     public DKLocalAccountIdentification getDKLocalAccountIdentification() throws ClassCastException {
         return (DKLocalAccountIdentification)super.getActualInstance();
+    }
+
+    /**
+     * Get the actual instance of `HKLocalAccountIdentification`. If the actual instance is not `HKLocalAccountIdentification`,
+     * the ClassCastException will be thrown.
+     *
+     * @return The actual instance of `HKLocalAccountIdentification`
+     * @throws ClassCastException if the instance is not `HKLocalAccountIdentification`
+     */
+    public HKLocalAccountIdentification getHKLocalAccountIdentification() throws ClassCastException {
+        return (HKLocalAccountIdentification)super.getActualInstance();
     }
 
     /**
@@ -939,5 +987,24 @@ public class BankAccountV3AccountIdentification extends AbstractOpenApiSchema {
         return (USLocalAccountIdentification)super.getActualInstance();
     }
 
+    /**
+    * Create an instance of BankAccountV3AccountIdentification given an JSON string
+    *
+    * @param jsonString JSON string
+    * @return An instance of BankAccountV3AccountIdentification
+    * @throws IOException if the JSON string is invalid with respect to BankAccountV3AccountIdentification
+    */
+    public static BankAccountV3AccountIdentification fromJson(String jsonString) throws IOException {
+        return JSON.getMapper().readValue(jsonString, BankAccountV3AccountIdentification.class);
+    }
+
+    /**
+    * Convert an instance of BankAccountV3AccountIdentification to an JSON string
+    *
+    * @return JSON string
+    */
+    public String toJson() throws JsonProcessingException {
+        return JSON.getMapper().writeValueAsString(this);
+    }
 }
 

--- a/src/main/java/com/adyen/model/transfers/HKLocalAccountIdentification.java
+++ b/src/main/java/com/adyen/model/transfers/HKLocalAccountIdentification.java
@@ -28,30 +28,26 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 
 /**
- * BRLocalAccountIdentification
+ * HKLocalAccountIdentification
  */
 @JsonPropertyOrder({
-  BRLocalAccountIdentification.JSON_PROPERTY_ACCOUNT_NUMBER,
-  BRLocalAccountIdentification.JSON_PROPERTY_BANK_CODE,
-  BRLocalAccountIdentification.JSON_PROPERTY_BRANCH_NUMBER,
-  BRLocalAccountIdentification.JSON_PROPERTY_TYPE
+  HKLocalAccountIdentification.JSON_PROPERTY_ACCOUNT_NUMBER,
+  HKLocalAccountIdentification.JSON_PROPERTY_BANK_CODE,
+  HKLocalAccountIdentification.JSON_PROPERTY_TYPE
 })
 
-public class BRLocalAccountIdentification {
+public class HKLocalAccountIdentification {
   public static final String JSON_PROPERTY_ACCOUNT_NUMBER = "accountNumber";
   private String accountNumber;
 
   public static final String JSON_PROPERTY_BANK_CODE = "bankCode";
   private String bankCode;
 
-  public static final String JSON_PROPERTY_BRANCH_NUMBER = "branchNumber";
-  private String branchNumber;
-
   /**
-   * **brLocal**
+   * **hkLocal**
    */
   public enum TypeEnum {
-    BRLOCAL("brLocal");
+    HKLOCAL("hkLocal");
 
     private String value;
 
@@ -81,21 +77,21 @@ public class BRLocalAccountIdentification {
   }
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  private TypeEnum type = TypeEnum.BRLOCAL;
+  private TypeEnum type = TypeEnum.HKLOCAL;
 
-  public BRLocalAccountIdentification() { 
+  public HKLocalAccountIdentification() { 
   }
 
-  public BRLocalAccountIdentification accountNumber(String accountNumber) {
+  public HKLocalAccountIdentification accountNumber(String accountNumber) {
     this.accountNumber = accountNumber;
     return this;
   }
 
    /**
-   * The bank account number, without separators or whitespace.
+   * The 6- to 19-character bank account number (alphanumeric), without separators or whitespace.
    * @return accountNumber
   **/
-  @ApiModelProperty(required = true, value = "The bank account number, without separators or whitespace.")
+  @ApiModelProperty(required = true, value = "The 6- to 19-character bank account number (alphanumeric), without separators or whitespace.")
   @JsonProperty(JSON_PROPERTY_ACCOUNT_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -111,16 +107,16 @@ public class BRLocalAccountIdentification {
   }
 
 
-  public BRLocalAccountIdentification bankCode(String bankCode) {
+  public HKLocalAccountIdentification bankCode(String bankCode) {
     this.bankCode = bankCode;
     return this;
   }
 
    /**
-   * The 3-digit bank code, with leading zeros.
+   * The 6-digit bank code including the 3-digit bank code and 3-digit branch code, without separators or whitespace.
    * @return bankCode
   **/
-  @ApiModelProperty(required = true, value = "The 3-digit bank code, with leading zeros.")
+  @ApiModelProperty(required = true, value = "The 6-digit bank code including the 3-digit bank code and 3-digit branch code, without separators or whitespace.")
   @JsonProperty(JSON_PROPERTY_BANK_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -136,41 +132,16 @@ public class BRLocalAccountIdentification {
   }
 
 
-  public BRLocalAccountIdentification branchNumber(String branchNumber) {
-    this.branchNumber = branchNumber;
-    return this;
-  }
-
-   /**
-   * The bank account branch number, without separators or whitespace.
-   * @return branchNumber
-  **/
-  @ApiModelProperty(required = true, value = "The bank account branch number, without separators or whitespace.")
-  @JsonProperty(JSON_PROPERTY_BRANCH_NUMBER)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public String getBranchNumber() {
-    return branchNumber;
-  }
-
-
-  @JsonProperty(JSON_PROPERTY_BRANCH_NUMBER)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setBranchNumber(String branchNumber) {
-    this.branchNumber = branchNumber;
-  }
-
-
-  public BRLocalAccountIdentification type(TypeEnum type) {
+  public HKLocalAccountIdentification type(TypeEnum type) {
     this.type = type;
     return this;
   }
 
    /**
-   * **brLocal**
+   * **hkLocal**
    * @return type
   **/
-  @ApiModelProperty(required = true, value = "**brLocal**")
+  @ApiModelProperty(required = true, value = "**hkLocal**")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -187,7 +158,7 @@ public class BRLocalAccountIdentification {
 
 
   /**
-   * Return true if this BRLocalAccountIdentification object is equal to o.
+   * Return true if this HKLocalAccountIdentification object is equal to o.
    */
   @Override
   public boolean equals(Object o) {
@@ -197,25 +168,23 @@ public class BRLocalAccountIdentification {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    BRLocalAccountIdentification brLocalAccountIdentification = (BRLocalAccountIdentification) o;
-    return Objects.equals(this.accountNumber, brLocalAccountIdentification.accountNumber) &&
-        Objects.equals(this.bankCode, brLocalAccountIdentification.bankCode) &&
-        Objects.equals(this.branchNumber, brLocalAccountIdentification.branchNumber) &&
-        Objects.equals(this.type, brLocalAccountIdentification.type);
+    HKLocalAccountIdentification hkLocalAccountIdentification = (HKLocalAccountIdentification) o;
+    return Objects.equals(this.accountNumber, hkLocalAccountIdentification.accountNumber) &&
+        Objects.equals(this.bankCode, hkLocalAccountIdentification.bankCode) &&
+        Objects.equals(this.type, hkLocalAccountIdentification.type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(accountNumber, bankCode, branchNumber, type);
+    return Objects.hash(accountNumber, bankCode, type);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class BRLocalAccountIdentification {\n");
+    sb.append("class HKLocalAccountIdentification {\n");
     sb.append("    accountNumber: ").append(toIndentedString(accountNumber)).append("\n");
     sb.append("    bankCode: ").append(toIndentedString(bankCode)).append("\n");
-    sb.append("    branchNumber: ").append(toIndentedString(branchNumber)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -233,17 +202,17 @@ public class BRLocalAccountIdentification {
   }
 
 /**
-   * Create an instance of BRLocalAccountIdentification given an JSON string
+   * Create an instance of HKLocalAccountIdentification given an JSON string
    *
    * @param jsonString JSON string
-   * @return An instance of BRLocalAccountIdentification
-   * @throws JsonProcessingException if the JSON string is invalid with respect to BRLocalAccountIdentification
+   * @return An instance of HKLocalAccountIdentification
+   * @throws JsonProcessingException if the JSON string is invalid with respect to HKLocalAccountIdentification
    */
-  public static BRLocalAccountIdentification fromJson(String jsonString) throws JsonProcessingException {
-    return JSON.getMapper().readValue(jsonString, BRLocalAccountIdentification.class);
+  public static HKLocalAccountIdentification fromJson(String jsonString) throws JsonProcessingException {
+    return JSON.getMapper().readValue(jsonString, HKLocalAccountIdentification.class);
   }
 /**
-  * Convert an instance of BRLocalAccountIdentification to an JSON string
+  * Convert an instance of HKLocalAccountIdentification to an JSON string
   *
   * @return JSON string
   */

--- a/src/main/java/com/adyen/model/transfers/Transaction.java
+++ b/src/main/java/com/adyen/model/transfers/Transaction.java
@@ -42,7 +42,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
   Transaction.JSON_PROPERTY_CATEGORY,
   Transaction.JSON_PROPERTY_COUNTERPARTY,
   Transaction.JSON_PROPERTY_CREATED_AT,
+  Transaction.JSON_PROPERTY_CREATION_DATE,
   Transaction.JSON_PROPERTY_DESCRIPTION,
+  Transaction.JSON_PROPERTY_EVENT_ID,
   Transaction.JSON_PROPERTY_ID,
   Transaction.JSON_PROPERTY_INSTRUCTED_AMOUNT,
   Transaction.JSON_PROPERTY_PAYMENT_INSTRUMENT_ID,
@@ -124,8 +126,14 @@ public class Transaction {
   public static final String JSON_PROPERTY_CREATED_AT = "createdAt";
   private OffsetDateTime createdAt;
 
+  public static final String JSON_PROPERTY_CREATION_DATE = "creationDate";
+  private OffsetDateTime creationDate;
+
   public static final String JSON_PROPERTY_DESCRIPTION = "description";
   private String description;
+
+  public static final String JSON_PROPERTY_EVENT_ID = "eventId";
+  private String eventId;
 
   public static final String JSON_PROPERTY_ID = "id";
   private String id;
@@ -477,6 +485,31 @@ public class Transaction {
   }
 
 
+  public Transaction creationDate(OffsetDateTime creationDate) {
+    this.creationDate = creationDate;
+    return this;
+  }
+
+   /**
+   * The date and time when the event was triggered, in ISO 8601 extended format. For example, **2020-12-18T10:15:30+01:00**.
+   * @return creationDate
+  **/
+  @ApiModelProperty(value = "The date and time when the event was triggered, in ISO 8601 extended format. For example, **2020-12-18T10:15:30+01:00**.")
+  @JsonProperty(JSON_PROPERTY_CREATION_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public OffsetDateTime getCreationDate() {
+    return creationDate;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CREATION_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCreationDate(OffsetDateTime creationDate) {
+    this.creationDate = creationDate;
+  }
+
+
   public Transaction description(String description) {
     this.description = description;
     return this;
@@ -499,6 +532,31 @@ public class Transaction {
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDescription(String description) {
     this.description = description;
+  }
+
+
+  public Transaction eventId(String eventId) {
+    this.eventId = eventId;
+    return this;
+  }
+
+   /**
+   * The PSP reference in the journal.
+   * @return eventId
+  **/
+  @ApiModelProperty(value = "The PSP reference in the journal.")
+  @JsonProperty(JSON_PROPERTY_EVENT_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public String getEventId() {
+    return eventId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EVENT_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setEventId(String eventId) {
+    this.eventId = eventId;
   }
 
 
@@ -747,7 +805,9 @@ public class Transaction {
         Objects.equals(this.category, transaction.category) &&
         Objects.equals(this.counterparty, transaction.counterparty) &&
         Objects.equals(this.createdAt, transaction.createdAt) &&
+        Objects.equals(this.creationDate, transaction.creationDate) &&
         Objects.equals(this.description, transaction.description) &&
+        Objects.equals(this.eventId, transaction.eventId) &&
         Objects.equals(this.id, transaction.id) &&
         Objects.equals(this.instructedAmount, transaction.instructedAmount) &&
         Objects.equals(this.paymentInstrumentId, transaction.paymentInstrumentId) &&
@@ -761,7 +821,7 @@ public class Transaction {
 
   @Override
   public int hashCode() {
-    return Objects.hash(accountHolderId, amount, balanceAccountId, balancePlatform, bookingDate, category, counterparty, createdAt, description, id, instructedAmount, paymentInstrumentId, reference, referenceForBeneficiary, status, transferId, type, valueDate);
+    return Objects.hash(accountHolderId, amount, balanceAccountId, balancePlatform, bookingDate, category, counterparty, createdAt, creationDate, description, eventId, id, instructedAmount, paymentInstrumentId, reference, referenceForBeneficiary, status, transferId, type, valueDate);
   }
 
   @Override
@@ -776,7 +836,9 @@ public class Transaction {
     sb.append("    category: ").append(toIndentedString(category)).append("\n");
     sb.append("    counterparty: ").append(toIndentedString(counterparty)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
+    sb.append("    creationDate: ").append(toIndentedString(creationDate)).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("    eventId: ").append(toIndentedString(eventId)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
     sb.append("    paymentInstrumentId: ").append(toIndentedString(paymentInstrumentId)).append("\n");

--- a/src/main/java/com/adyen/model/transfers/Transfer.java
+++ b/src/main/java/com/adyen/model/transfers/Transfer.java
@@ -382,6 +382,14 @@ public class Transfer {
     
     MISCCOSTPENDING("miscCostPending"),
     
+    OPERATIONAUTHORIZED("operationAuthorized"),
+    
+    OPERATIONBOOKED("operationBooked"),
+    
+    OPERATIONPENDING("operationPending"),
+    
+    OPERATIONRECEIVED("operationReceived"),
+    
     PAYMENTCOST("paymentCost"),
     
     PAYMENTCOSTPENDING("paymentCostPending"),

--- a/src/test/java/com/adyen/CheckoutTest.java
+++ b/src/test/java/com/adyen/CheckoutTest.java
@@ -438,9 +438,12 @@ public class CheckoutTest extends BaseTest {
 
     @Test
     public void TestCheckoutPaymentMethodSerialisation() throws Exception {
+        // Checks that unknown parameters (in this case googlePayCardNetwork) in oneOf classes are not strict and will
+        // not throw an error.
         CheckoutPaymentMethod checkoutPaymentMethodGoogle = CheckoutPaymentMethod.fromJson("{\n" +
                 "    \"type\": \"paywithgoogle\",\n" +
-                "    \"googlePayToken\": \"==Payload as retrieved from Google Pay response==\"\n" +
+                "    \"googlePayToken\": \"==Payload as retrieved from Google Pay response==\",\n" +
+                "    \"googlePayCardNetwork\": \"not supposed to be here\"\n" +
                 "  }");
 
         CheckoutPaymentMethod checkoutPaymentMethodScheme = CheckoutPaymentMethod.fromJson("{\n" +
@@ -449,7 +452,8 @@ public class CheckoutTest extends BaseTest {
                 "    \"cvc\": \"737\",\n" +
                 "    \"expiryMonth\": \"03\",\n" +
                 "    \"expiryYear\": \"2030\",\n" +
-                "    \"holderName\": \"John Smith\"\n" +
+                "    \"holderName\": \"John Smith\",\n" +
+                "    \"someMumboJumbo\": \"value\"\n" +
                 "  }");
 
         CheckoutPaymentMethod checkoutPaymentMethodApple = CheckoutPaymentMethod.fromJson("{\n" +

--- a/templates/libraries/jersey3/oneof_model.mustache
+++ b/templates/libraries/jersey3/oneof_model.mustache
@@ -79,9 +79,6 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
             boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
             int match = 0;
             JsonToken token = tree.traverse(jp.getCodec()).nextToken();
-            // Local Object Mapper that forces strict validation
-            ObjectMapper localObjectMapper = JSON.getMapper();
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
             {{#oneOf}}
 
             // deserialize {{{.}}}
@@ -104,7 +101,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                 boolean typeMatch = Arrays.stream({{{.}}}.TypeEnum.values()).anyMatch((t) -> t.getValue().contains(tree.findValue("type").asText()));
                 if (attemptParsing || typeMatch) {
                     // Strict deserialization for oneOf models
-                    deserialized = localObjectMapper.readValue(tree.toString(), {{{.}}}.class);
+                    deserialized = JSON.getMapper().readValue(tree.toString(), {{{.}}}.class);
                     // typeMatch should enforce proper deserialization
                     match++;
                     log.log(Level.FINER, "Input data matches schema '{{{.}}}'");
@@ -124,7 +121,6 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                 log.log(Level.WARNING, String.format("Warning, indecisive deserialization for {{classname}}: %d classes match result, expected 1", match));
             }
 
-            localObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             {{classname}} ret = new {{classname}}();
             ret.setActualInstance(deserialized);
             return ret;


### PR DESCRIPTION
**Description**
With the fix done for CronSweepSchedule there is no need anymore for soft validation in oneOf's. I removed the custom jsonMapper with strict validation and instead opted again for the default value as every oneOf can now be validated on type solely.
