### PR TITLE
Allow passing baseURL directly when constructing API services

### DIFF
--- a/src/main/java/com/adyen/service/checkout/ClassicCheckoutSdkApi.java
+++ b/src/main/java/com/adyen/service/checkout/ClassicCheckoutSdkApi.java
@@ -28,11 +28,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ClassicCheckoutSdkApi extends Service {
+
+    public static final String API_VERSION = "70";
+
     protected String baseURL;
 
     public ClassicCheckoutSdkApi(Client client) {
         super(client);
         this.baseURL = createBaseURL("https://checkout-test.adyen.com/v70");
+    }
+
+    public ClassicCheckoutSdkApi(Client client, String baseURL) {
+        super(client);
+        this.baseURL = baseURL;
     }
 
     /**

--- a/src/main/java/com/adyen/service/checkout/ModificationsApi.java
+++ b/src/main/java/com/adyen/service/checkout/ModificationsApi.java
@@ -36,11 +36,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ModificationsApi extends Service {
+
+    public static final String API_VERSION = "70";
+
     protected String baseURL;
 
     public ModificationsApi(Client client) {
         super(client);
         this.baseURL = createBaseURL("https://checkout-test.adyen.com/v70");
+    }
+
+    public ModificationsApi(Client client, String baseURL) {
+        super(client);
+        this.baseURL = baseURL;
     }
 
     /**

--- a/src/main/java/com/adyen/service/checkout/OrdersApi.java
+++ b/src/main/java/com/adyen/service/checkout/OrdersApi.java
@@ -30,11 +30,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class OrdersApi extends Service {
+
+    public static final String API_VERSION = "70";
+
     protected String baseURL;
 
     public OrdersApi(Client client) {
         super(client);
         this.baseURL = createBaseURL("https://checkout-test.adyen.com/v70");
+    }
+
+    public OrdersApi(Client client, String baseURL) {
+        super(client);
+        this.baseURL = baseURL;
     }
 
     /**

--- a/src/main/java/com/adyen/service/checkout/PaymentLinksApi.java
+++ b/src/main/java/com/adyen/service/checkout/PaymentLinksApi.java
@@ -27,11 +27,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PaymentLinksApi extends Service {
+
+    public static final String API_VERSION = "70";
+
     protected String baseURL;
 
     public PaymentLinksApi(Client client) {
         super(client);
         this.baseURL = createBaseURL("https://checkout-test.adyen.com/v70");
+    }
+
+    public PaymentLinksApi(Client client, String baseURL) {
+        super(client);
+        this.baseURL = baseURL;
     }
 
     /**

--- a/src/main/java/com/adyen/service/checkout/PaymentsApi.java
+++ b/src/main/java/com/adyen/service/checkout/PaymentsApi.java
@@ -37,11 +37,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PaymentsApi extends Service {
+
+    public static final String API_VERSION = "70";
+
     protected String baseURL;
 
     public PaymentsApi(Client client) {
         super(client);
         this.baseURL = createBaseURL("https://checkout-test.adyen.com/v70");
+    }
+
+    public PaymentsApi(Client client, String baseURL) {
+        super(client);
+        this.baseURL = baseURL;
     }
 
     /**

--- a/src/main/java/com/adyen/service/checkout/RecurringApi.java
+++ b/src/main/java/com/adyen/service/checkout/RecurringApi.java
@@ -25,11 +25,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class RecurringApi extends Service {
+
+    public static final String API_VERSION = "70";
+
     protected String baseURL;
 
     public RecurringApi(Client client) {
         super(client);
         this.baseURL = createBaseURL("https://checkout-test.adyen.com/v70");
+    }
+
+    public RecurringApi(Client client, String baseURL) {
+        super(client);
+        this.baseURL = baseURL;
     }
 
     /**

--- a/src/main/java/com/adyen/service/checkout/UtilityApi.java
+++ b/src/main/java/com/adyen/service/checkout/UtilityApi.java
@@ -28,11 +28,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class UtilityApi extends Service {
+
+    public static final String API_VERSION = "70";
+
     protected String baseURL;
 
     public UtilityApi(Client client) {
         super(client);
         this.baseURL = createBaseURL("https://checkout-test.adyen.com/v70");
+    }
+
+    public UtilityApi(Client client, String baseURL) {
+        super(client);
+        this.baseURL = baseURL;
     }
 
     /**

--- a/templates/libraries/jersey3/api.mustache
+++ b/templates/libraries/jersey3/api.mustache
@@ -16,11 +16,19 @@ import java.util.Map;
 
 {{#operations}}
 public class {{classname}} extends Service {
+
+    public static final String API_VERSION = "{{{version}}}";
+
     protected String baseURL;
 
     public {{classname}}(Client client) {
         super(client);
         this.baseURL = createBaseURL("{{{basePath}}}");
+    }
+
+    public {{classname}}(Client client, String baseURL) {
+        super(client);
+        this.baseURL = baseURL;
     }
 {{#operation}}
 


### PR DESCRIPTION
The implementation of `createBaseURL(...)` forces us to use HTTPS, but we need our app servers to use HTTP and let our service mesh catch and encrypt the outgoing requests before they leave our system (transparent from your point of view, the requests will always reach you through HTTPS).

One backward-compatible approach could be as proposed here: allow the `baseURL` to be passed to the constructor directly. It would greatly simplify our usage, given we currently have to hack around by overriding `createBaseURL(...)` thanks to its `protected` visibility.

Let me know what you think.