### PR TITLE
Update fields with javadoc description from open api specs

### DIFF
--- a/templates/libraries/jersey3/pojo.mustache
+++ b/templates/libraries/jersey3/pojo.mustache
@@ -204,7 +204,10 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     {{/vendorExtensions.x-is-jackson-optional-nullable}}
   }
 
-  {{#vendorExtensions.x-is-jackson-optional-nullable}}
+
+/**
+ *{{description}}{{^description}}{{name}}{{/description}}
+ */ {{#vendorExtensions.x-is-jackson-optional-nullable}}
 {{> jackson_annotations}}
   public JsonNullable<{{{datatypeWithEnum}}}> {{getter}}_JsonNullable() {
     return {{name}};

--- a/templates/libraries/jersey3/pojo.mustache
+++ b/templates/libraries/jersey3/pojo.mustache
@@ -205,9 +205,11 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   }
 
 
-/**
- *{{description}}{{^description}}{{name}}{{/description}}
- */ {{#vendorExtensions.x-is-jackson-optional-nullable}}
+ /**
+  * {{description}}{{^description}}{{name}}{{/description}}
+  *
+  * @param {{name}}
+  */ {{#vendorExtensions.x-is-jackson-optional-nullable}}
 {{> jackson_annotations}}
   public JsonNullable<{{{datatypeWithEnum}}}> {{getter}}_JsonNullable() {
     return {{name}};


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Update the `pojo.mustache` to add description  with param on models setters for javadoc.
**Tested scenarios**
Generate the models and the setters has javadoc based on the openapi specs 

