### PR TITLE
TaxReportingClassification fix for issue #1265

### DIFF
--- a/src/main/java/com/adyen/model/legalentitymanagement/TaxReportingClassification.java
+++ b/src/main/java/com/adyen/model/legalentitymanagement/TaxReportingClassification.java
@@ -52,7 +52,7 @@ public class TaxReportingClassification {
     
     INTERNATIONALORGANIZATION("internationalOrganization"),
     
-    FINANCIALINSTITUTION_("financialInstitution.");
+    FINANCIALINSTITUTION("financialInstitution");
 
     private String value;
 


### PR DESCRIPTION
**Description**
Removed unnecessary underscore and period from TaxReportingClassification type

**Tested scenarios**
 Called BusinessTypeEnum.fromValue("financialInstitution"); to verify there was no error. 

**Fixed issue**:  #1265 
