### PR TITLE
misc(notification): Add expire code to constants

### DIFF
--- a/src/main/java/com/adyen/model/notification/NotificationRequestItem.java
+++ b/src/main/java/com/adyen/model/notification/NotificationRequestItem.java
@@ -52,6 +52,7 @@ public class NotificationRequestItem {
     public static final String EVENT_CODE_PROCESS_RETRY = "PROCESS_RETRY";
     public static final String EVENT_CODE_REPORT_AVAILABLE = "REPORT_AVAILABLE";
     public static final String EVENT_CODE_VOID_PENDING_REFUND = "VOID_PENDING_REFUND";
+    public static final String EVENT_CODE_EXPIRE = "EXPIRE";
 
     //Dispute Event Codes
     public static final String EVENT_CODE_CHARGEBACK = "CHARGEBACK";


### PR DESCRIPTION
Minor change, adding the EXPIRE notification type to the NotificationRequestItem constants for import on our side when treating expire notifications
<img width="775" alt="image" src="https://github.com/Adyen/adyen-java-api-library/assets/113363263/4092be60-d306-4ade-9522-5dc18c064a31">
As seen on the [documentation](https://docs.adyen.com/development-resources/webhooks/webhook-types/#event-codes)
