### PR TITLE
downgraded Jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,12 +184,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.17.2</version>
+            <version>2.12.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.2</version>
+            <version>2.12.7</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Downgraded Jackson dependencies in pom.xml to version 2.12.7 to add support for Android 7. 

Unit-tests did not fail. 
Creating a pull request to check if other tests are successful too.
