### PR TITLE
Downgrade dependency Base64 for terminal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,11 @@
             <version>3.9.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version> <!-- or the latest version -->
+        </dependency>
         <!-- Generated model annotations -->
         <dependency>
             <groupId>io.swagger</groupId>

--- a/src/main/java/com/adyen/model/terminal/SaleToAcquirerData.java
+++ b/src/main/java/com/adyen/model/terminal/SaleToAcquirerData.java
@@ -27,7 +27,7 @@ import java.io.Reader;
 import java.util.Map;
 import java.util.Objects;
 
-import java.util.Base64;
+import org.apache.commons.codec.binary.Base64;
 import com.adyen.model.applicationinfo.ApplicationInfo;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -278,11 +278,12 @@ public class SaleToAcquirerData {
 
     public String toBase64() {
         String json = PRETTY_PRINT_GSON.toJson(this);
-        return new String(Base64.getEncoder().encode(json.getBytes()));
+        byte[] encodedBytes = Base64.encodeBase64(json.getBytes());
+        return new String(encodedBytes);
     }
 
     public static SaleToAcquirerData fromBase64(String base64) {
-        byte[] decoded = Base64.getDecoder().decode(base64);
+        byte[] decoded = Base64.decodeBase64(base64);
         try (Reader reader = new InputStreamReader(new ByteArrayInputStream(decoded))) {
             return PRETTY_PRINT_GSON.fromJson(reader, SaleToAcquirerData.class);
         }

--- a/src/main/java/com/adyen/terminal/security/NexoCrypto.java
+++ b/src/main/java/com/adyen/terminal/security/NexoCrypto.java
@@ -27,7 +27,7 @@ import com.adyen.model.terminal.security.SaleToPOISecuredMessage;
 import com.adyen.model.terminal.security.SecurityKey;
 import com.adyen.model.terminal.security.SecurityTrailer;
 import com.adyen.terminal.security.exception.NexoCryptoException;
-import java.util.Base64;
+import org.apache.commons.codec.binary.Base64;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -74,7 +74,7 @@ public class NexoCrypto {
 
         SaleToPOISecuredMessage saleToPoiSecuredMessage = new SaleToPOISecuredMessage();
         saleToPoiSecuredMessage.setMessageHeader(messageHeader);
-        saleToPoiSecuredMessage.setNexoBlob(new String(Base64.getEncoder().encode(encryptedSaleToPoiMessage)));
+        saleToPoiSecuredMessage.setNexoBlob(new String(Base64.encodeBase64(encryptedSaleToPoiMessage)));
         saleToPoiSecuredMessage.setSecurityTrailer(securityTrailer);
 
         return saleToPoiSecuredMessage;
@@ -82,7 +82,7 @@ public class NexoCrypto {
 
     public String decrypt(SaleToPOISecuredMessage saleToPoiSecuredMessage) throws Exception {
         NexoDerivedKey derivedKey = getNexoDerivedKey();
-        byte[] encryptedSaleToPoiMessageByteArray = Base64.getDecoder().decode(saleToPoiSecuredMessage.getNexoBlob().getBytes());
+        byte[] encryptedSaleToPoiMessageByteArray = Base64.decodeBase64(saleToPoiSecuredMessage.getNexoBlob().getBytes());
         byte[] ivNonce = saleToPoiSecuredMessage.getSecurityTrailer().getNonce();
         byte[] decryptedSaleToPoiMessageByteArray = crypt(encryptedSaleToPoiMessageByteArray, derivedKey, ivNonce, Cipher.DECRYPT_MODE);
 

--- a/src/test/java/com/adyen/serializer/SaleToAcquirerDataSerializerTest.java
+++ b/src/test/java/com/adyen/serializer/SaleToAcquirerDataSerializerTest.java
@@ -7,7 +7,7 @@ import com.adyen.model.terminal.SaleToAcquirerData;
 import com.google.gson.Gson;
 import com.google.gson.JsonParser;
 import com.google.gson.GsonBuilder;
-import java.util.Base64;
+import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -105,7 +105,7 @@ public class SaleToAcquirerDataSerializerTest {
         
         // test if base64 works
         String serialized = saleToAcquirerDataModelAdapter.serialize(saleToAcquirerData, null, null).getAsString();
-        SaleToAcquirerData saleToAcquirerDataDecoded = new Gson().fromJson(new String(Base64.getDecoder().decode(serialized)), SaleToAcquirerData.class);
+        SaleToAcquirerData saleToAcquirerDataDecoded = new Gson().fromJson(new String(Base64.decodeBase64(serialized)), SaleToAcquirerData.class);
         assertEquals(saleToAcquirerData, saleToAcquirerDataDecoded);
     }
 


### PR DESCRIPTION
Commons-codec provides Base64 encoding and decoding support for Android 7

- added import in SaleToAcquirerData.java in Terminal API and adjusted methods
- added dependency in pom.xml
- adjusted unit-test SaleToAcquirerDataSerializerTest.java.
