### PR TITLE
Run CodeQL analysis on cron job only

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,6 @@
 name: "Code scanning - action"
 
 on:
-  push:
-  pull_request:
   schedule:
     - cron: '0 0 * * 4'
 


### PR DESCRIPTION
**Description**
CodeQL workflows runs on `push`, `pull_request` and `cron`.

This PR updates the workflow configuration to run on `cron` only.