### PR TITLE
Finish migrating java util base64 to apache commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.3.1</version>
+            <version>5.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
+++ b/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
@@ -24,7 +24,7 @@ import com.adyen.Client;
 import com.adyen.Config;
 import com.adyen.constants.ApiConstants;
 import com.adyen.model.RequestOptions;
-import java.util.Base64;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPatch;
@@ -244,7 +244,7 @@ public class AdyenHttpClient implements ClientInterface {
     private void setBasicAuthentication(HttpUriRequest httpUriRequest, String username, String password) {
         // set basic authentication
         String authString = username + ":" + password;
-        byte[] authEncBytes = Base64.getEncoder().encode(authString.getBytes());
+        byte[] authEncBytes = Base64.encodeBase64(authString.getBytes());
         String authStringEnc = new String(authEncBytes);
 
         httpUriRequest.addHeader("Authorization", "Basic " + authStringEnc);

--- a/src/main/java/com/adyen/terminal/serialization/ByteArrayToBase64TypeAdapter.java
+++ b/src/main/java/com/adyen/terminal/serialization/ByteArrayToBase64TypeAdapter.java
@@ -28,15 +28,15 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import java.util.Base64;
+import org.apache.commons.codec.binary.Base64;
 import java.lang.reflect.Type;
 
 public class ByteArrayToBase64TypeAdapter implements JsonSerializer<byte[]>, JsonDeserializer<byte[]> {
     public byte[] deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-        return Base64.getDecoder().decode(json.getAsString().getBytes());
+        return Base64.decodeBase64(json.getAsString().getBytes());
     }
 
     public JsonElement serialize(byte[] src, Type typeOfSrc, JsonSerializationContext context) {
-        return new JsonPrimitive(new String(Base64.getEncoder().encode(src)));
+        return new JsonPrimitive(new String(Base64.encodeBase64(src)));
     }
 }

--- a/src/main/java/com/adyen/util/HMACValidator.java
+++ b/src/main/java/com/adyen/util/HMACValidator.java
@@ -22,7 +22,7 @@ package com.adyen.util;
 
 import com.adyen.model.notification.Amount;
 import com.adyen.model.notification.NotificationRequestItem;
-import java.util.Base64;
+import org.apache.commons.codec.binary.Base64;
 import javax.xml.bind.DatatypeConverter;
 
 import javax.crypto.Mac;
@@ -60,7 +60,7 @@ public class HMACValidator {
             byte[] rawHmac = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
 
             // Base64-encode the hmac
-            return new String(Base64.getEncoder().encode(rawHmac));
+            return new String(Base64.encodeBase64(rawHmac));
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Missing data or key.");
         } catch (Exception e) {

--- a/src/test/java/com/adyen/LegalEntityManagementTest.java
+++ b/src/test/java/com/adyen/LegalEntityManagementTest.java
@@ -7,7 +7,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Base64;
+import org.apache.commons.codec.binary.Base64;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -320,7 +320,7 @@ public class LegalEntityManagementTest extends BaseTest {
                 "    \"type\": \"bankStatement\"\n" +
                 "}");
         Document response = service.updateDocument("SE322KT223222D5FJ7TJN2986", request);
-        assertEquals("Thisisanbase64encodedstring", new String(Base64.getDecoder().decode(response.getAttachments().get(0).getContent())));
+        assertEquals("Thisisanbase64encodedstring", new String(Base64.decodeBase64(response.getAttachments().get(0).getContent())));
     }
 
     @Test

--- a/src/test/java/com/adyen/PaymentTest.java
+++ b/src/test/java/com/adyen/PaymentTest.java
@@ -30,13 +30,10 @@ import com.adyen.model.payment.*;
 import com.adyen.service.PaymentApi;
 import com.adyen.service.exception.ApiException;
 import com.adyen.util.DateUtil;
-import com.fasterxml.jackson.databind.JavaType;
-import com.google.gson.reflect.TypeToken;
 import okio.ByteString;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -44,7 +41,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.Base64;
+import org.apache.commons.codec.binary.Base64;
 
 import static com.adyen.constants.ApiConstants.AdditionalData.*;
 import static com.adyen.constants.ApiConstants.SelectedBrand.BOLETO_SANTANDER;
@@ -454,7 +451,7 @@ public class PaymentTest extends BaseTest {
         byte[] actualDeserializedBytes = JSON.getMapper().readValue(serializedBytesWithQuotes, byte[].class);
 
         // Assert
-        assertEquals(expectedBytesAsString, new String(Base64.getDecoder().decode(actualDeserializedBytes)));
+        assertEquals(expectedBytesAsString, new String(Base64.decodeBase64(actualDeserializedBytes)));
     }
 
     @Test

--- a/src/test/java/com/adyen/serializer/ByteArrayToStringAdapterTest.java
+++ b/src/test/java/com/adyen/serializer/ByteArrayToStringAdapterTest.java
@@ -22,7 +22,8 @@ package com.adyen.serializer;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
-import java.util.Base64;import org.junit.Test;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -35,7 +36,7 @@ public class ByteArrayToStringAdapterTest {
     @Test
     public void testSerialize() {
         ByteArrayToStringAdapter adapter = new ByteArrayToStringAdapter();
-        byte[] base64Bytes = Base64.getEncoder().encode("Bytes-To-Be-Encoded".getBytes());
+        byte[] base64Bytes = Base64.encodeBase64("Bytes-To-Be-Encoded".getBytes());
 
         JsonElement serializedElement = adapter.serialize(base64Bytes, null, null);
         assertEquals("Qnl0ZXMtVG8tQmUtRW5jb2RlZA==", serializedElement.getAsString());
@@ -44,7 +45,7 @@ public class ByteArrayToStringAdapterTest {
     @Test
     public void testDeserialize() {
         ByteArrayToStringAdapter adapter = new ByteArrayToStringAdapter();
-        byte[] base64Bytes = Base64.getEncoder().encode("Bytes-To-Be-Encoded".getBytes());
+        byte[] base64Bytes = Base64.encodeBase64("Bytes-To-Be-Encoded".getBytes());
 
         JsonElement element = new JsonPrimitive("Qnl0ZXMtVG8tQmUtRW5jb2RlZA==");
         byte[] deserializedBytes = adapter.deserialize(element, null, null);


### PR DESCRIPTION
**Description**
In order to support android versions 7  and higher we decided to change `java.util.Base64` in favour of the `org.apache.commons.codec.binary.Base64` library. This PR serves to finish this migration. 