### PR TITLE
fix(exception): better handle non-JSON response bodies

### DIFF
--- a/src/main/java/com/adyen/service/resource/Resource.java
+++ b/src/main/java/com/adyen/service/resource/Resource.java
@@ -29,6 +29,8 @@ import com.adyen.httpclient.HTTPClientException;
 import com.adyen.model.ApiError;
 import com.adyen.model.RequestOptions;
 import com.adyen.service.exception.ApiException;
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.google.gson.Gson;
 
 import java.io.IOException;
@@ -113,7 +115,11 @@ public class Resource {
         } catch (HTTPClientException e) {
             apiException = new ApiException(e.getMessage(), e.getCode(), e.getResponseHeaders());
             apiException.setResponseBody(e.getResponseBody());
-            apiException.setError(ApiError.fromJson(e.getResponseBody()));
+            try {
+                apiException.setError(ApiError.fromJson(e.getResponseBody()));
+            } catch (Exception ignore) {
+                // Response body could not be parsed (e.g. not JSON), raw response body available in ApiException#responseBody
+            }
         }
         throw apiException;
     }

--- a/src/test/java/com/adyen/service/ResourceTest.java
+++ b/src/test/java/com/adyen/service/ResourceTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -90,7 +91,7 @@ public class ResourceTest extends BaseTest {
         Resource resource = new Resource(serviceMock, "/companies/{companyId}/merchants", null);
 
         HTTPClientException error = new HTTPClientException(500, "error", Collections.emptyMap(), "not JSON");
-        when(clientInterfaceMock.request(any(), any(), any(), any(), any(), any(), any())).thenThrow(error);
+        when(clientInterfaceMock.request(any(), any(), any(), anyBoolean(), any(), any(), any())).thenThrow(error);
 
         ApiException thrown = assertThrows(ApiException.class, () -> resource.request(null, null, ApiConstants.HttpMethod.GET, pathParams, queryString));
         assertEquals("not JSON", thrown.getResponseBody());

--- a/src/test/java/com/adyen/service/ResourceTest.java
+++ b/src/test/java/com/adyen/service/ResourceTest.java
@@ -90,7 +90,7 @@ public class ResourceTest extends BaseTest {
         Resource resource = new Resource(serviceMock, "/companies/{companyId}/merchants", null);
 
         HTTPClientException error = new HTTPClientException(500, "error", Collections.emptyMap(), "not JSON");
-        when(clientInterfaceMock.request(any(),any(),any(),any(),any(),any(),any())).thenThrow(error);
+        when(clientInterfaceMock.request(any(), any(), any(), any(), any(), any(), any())).thenThrow(error);
 
         ApiException thrown = assertThrows(ApiException.class, () -> resource.request(null, null, ApiConstants.HttpMethod.GET, pathParams, queryString));
         assertEquals("not JSON", thrown.getResponseBody());

--- a/src/test/java/com/adyen/service/ResourceTest.java
+++ b/src/test/java/com/adyen/service/ResourceTest.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -76,10 +77,24 @@ public class ResourceTest extends BaseTest {
         Map<String, String> pathParams = Collections.singletonMap("companyId", "adyen");
         Map<String, String> queryString = Collections.singletonMap("pageSize", "10");
         Resource resource = new Resource(serviceMock, "/companies/{companyId}/merchants", null);
-        
+
         resource.request(null, null, ApiConstants.HttpMethod.GET, pathParams, queryString);
 
         verify(clientInterfaceMock).request("/companies/adyen/merchants", null, null, false, null, ApiConstants.HttpMethod.GET, queryString);
+    }
+
+    @Test
+    public void testNonJsonError() throws Exception {
+        Map<String, String> pathParams = Collections.singletonMap("companyId", "adyen");
+        Map<String, String> queryString = Collections.singletonMap("pageSize", "10");
+        Resource resource = new Resource(serviceMock, "/companies/{companyId}/merchants", null);
+
+        HTTPClientException error = new HTTPClientException(500, "error", Collections.emptyMap(), "not JSON");
+        when(clientInterfaceMock.request(any(),any(),any(),any(),any(),any(),any())).thenThrow(error);
+
+        ApiException thrown = assertThrows(ApiException.class, () -> resource.request(null, null, ApiConstants.HttpMethod.GET, pathParams, queryString));
+        assertEquals("not JSON", thrown.getResponseBody());
+        assertNull(thrown.getError());
     }
 
     @Test

--- a/src/test/java/com/adyen/service/ResourceTest.java
+++ b/src/test/java/com/adyen/service/ResourceTest.java
@@ -77,7 +77,7 @@ public class ResourceTest extends BaseTest {
         Map<String, String> pathParams = Collections.singletonMap("companyId", "adyen");
         Map<String, String> queryString = Collections.singletonMap("pageSize", "10");
         Resource resource = new Resource(serviceMock, "/companies/{companyId}/merchants", null);
-
+        
         resource.request(null, null, ApiConstants.HttpMethod.GET, pathParams, queryString);
 
         verify(clientInterfaceMock).request("/companies/adyen/merchants", null, null, false, null, ApiConstants.HttpMethod.GET, queryString);


### PR DESCRIPTION
When an error occurs and the response body isn't JSON (e.g. a misconfiguration of the base path triggering an HTML error page as a response), the code swallows the original error and instead throws a parsing exception.

This PR ensures parsing exceptions are ignored so that the original issue remains available.