### PR TITLE
feat(tls): allow disabling protocol upgrade

### DIFF
--- a/src/main/java/com/adyen/Config.java
+++ b/src/main/java/com/adyen/Config.java
@@ -17,6 +17,7 @@ public class Config {
     protected String apiKey;
     protected int connectionTimeoutMillis;
     protected int readTimeoutMillis;
+    protected Boolean protocolUpgradeEnabled;
 
     //Terminal API Specific
     protected String terminalApiCloudEndpoint;
@@ -99,6 +100,14 @@ public class Config {
 
     public void setReadTimeoutMillis(int readTimeoutMillis) {
         this.readTimeoutMillis = readTimeoutMillis;
+    }
+
+    public Boolean getProtocolUpgradeEnabled() {
+        return protocolUpgradeEnabled;
+    }
+
+    public void setProtocolUpgradeEnabled(Boolean protocolUpgradeEnabled) {
+        this.protocolUpgradeEnabled = protocolUpgradeEnabled;
     }
 
     public String getLiveEndpointUrlPrefix() {

--- a/src/main/java/com/adyen/Config.java
+++ b/src/main/java/com/adyen/Config.java
@@ -1,6 +1,7 @@
 package com.adyen;
 
 import com.adyen.enums.Environment;
+import org.apache.hc.client5.http.config.RequestConfig;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -106,6 +107,10 @@ public class Config {
         return protocolUpgradeEnabled;
     }
 
+    /**
+     * Whether the HTTP requests should automatically attempt to upgrade to a safer/newer version of the protocol.
+     * See also {@link RequestConfig.Builder#setProtocolUpgradeEnabled(boolean)}.
+     */
     public void setProtocolUpgradeEnabled(Boolean protocolUpgradeEnabled) {
         this.protocolUpgradeEnabled = protocolUpgradeEnabled;
     }

--- a/src/main/java/com/adyen/Config.java
+++ b/src/main/java/com/adyen/Config.java
@@ -1,7 +1,6 @@
 package com.adyen;
 
 import com.adyen.enums.Environment;
-import org.apache.hc.client5.http.config.RequestConfig;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;

--- a/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
+++ b/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
@@ -121,6 +121,9 @@ public class AdyenHttpClient implements ClientInterface {
         if (config.getConnectionTimeoutMillis() > 0) {
             builder.setConnectTimeout(config.getConnectionTimeoutMillis(), TimeUnit.MILLISECONDS);
         }
+        if (config.getProtocolUpgradeEnabled() != null) {
+            builder.setProtocolUpgradeEnabled(config.getProtocolUpgradeEnabled());
+        }
         if (proxy != null && proxy.address() instanceof InetSocketAddress) {
             InetSocketAddress inetSocketAddress = (InetSocketAddress) proxy.address();
             builder.setProxy(new HttpHost(inetSocketAddress.getHostName(), inetSocketAddress.getPort()));


### PR DESCRIPTION
Since version v29.1.0 of your SDK, you're relying on Apache HttpClient v5.4 ([diff](https://github.com/Adyen/adyen-java-api-library/compare/v29.0.0...v29.1.0)).

This version of HttpClient doesn't play well with Istio: https://github.com/istio/istio/issues/53239

A way to fix this is to disable the protocol upgrade, which HttpClient allows. This is what this PRs proposes.

It's also the recommended approach by Spring Boot: https://github.com/spring-projects/spring-boot/issues/43139 (while waiting for https://github.com/envoyproxy/envoy/issues/36305).