### PR TITLE
Fix failing failing step for external forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   release:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   SonarCloud-Build:
@@ -32,10 +32,15 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+
+      - name: Run Checkstyle
+        run: mvn checkstyle:check
+
       - name: Generate coverage report
         run: mvn test jacoco:report
 
       - name: Run SonarCloud Analysis
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
**Description**
This PR fixes failing workflow step for external forks by updating the CI pipeline by ensuring that release workflow and SonarCloud analysis are only executed for pull requests originating from branches within this repository, not from external forks. `Build` and `Test` would still run on external PR.