### PR TITLE
Ovverride default ApiError message with the error message from the API response

### DIFF
--- a/src/main/java/com/adyen/service/exception/ApiException.java
+++ b/src/main/java/com/adyen/service/exception/ApiException.java
@@ -25,16 +25,19 @@ import java.util.Map;
 import com.adyen.model.ApiError;
 
 /**
- * API Exception class
+ * API Exception thrown when there is an API error
+ *
+ * Check ApiError object to obtain the information about the error
  */
 public class ApiException extends Exception {
-    //Describes the error
+    // Object with the information about the error
     private ApiError error;
 
-    //HTTP status code
+    // HTTP status code
     private int statusCode;
 
     private Map<String, List<String>> responseHeaders;
+    // error JSON response
     private String responseBody;
 
     public ApiException(String message, int statusCode) {

--- a/src/test/java/com/adyen/BaseTest.java
+++ b/src/test/java/com/adyen/BaseTest.java
@@ -304,7 +304,7 @@ public class BaseTest {
     }
 
     /**
-     * Returns a Client that has a mocked error response from fileName
+     * Returns a Client that throws an exception with a given status and response
      */
     protected Client createMockClientForErrors(int status, String fileName) {
         String response = getFileContents(fileName);
@@ -312,7 +312,8 @@ public class BaseTest {
         AdyenHttpClient adyenHttpClient = mock(AdyenHttpClient.class);
         HTTPClientException httpClientException = new HTTPClientException(status, "An error occured", new HashMap<>(), response);
         try {
-            when(adyenHttpClient.request(anyString(), anyString(), any(Config.class), anyBoolean(), isNull(), any(), any())).thenThrow(httpClientException);
+            when(adyenHttpClient.request(anyString(), anyString(), any(Config.class), anyBoolean(), isNull(), any(), any()))
+                    .thenThrow(httpClientException);
         } catch (IOException | HTTPClientException e) {
             fail("Unexpected exception: " + e.getMessage());
         }

--- a/src/test/java/com/adyen/service/ResourceTest.java
+++ b/src/test/java/com/adyen/service/ResourceTest.java
@@ -142,6 +142,7 @@ public class ResourceTest extends BaseTest {
             fail("Expected exception");
         } catch (ApiException e) {
             assertEquals(422, e.getStatusCode());
+            assertEquals("Required field 'reference' is not provided. ErrorCode: 130", e.getMessage());
             assertNotNull(e.getError());
             assertEquals("validation", e.getError().getErrorType());
             assertEquals("Required field 'reference' is not provided.", e.getError().getMessage());
@@ -160,10 +161,28 @@ public class ResourceTest extends BaseTest {
             fail("Expected exception");
         } catch (ApiException e) {
             assertEquals(422, e.getStatusCode());
+            assertEquals("Invalid legal entity information provided ErrorCode: 30_102", e.getMessage());
             assertNotNull(e.getError());
             assertEquals("https://docs.adyen.com/errors/validation", e.getError().getErrorType());
             assertEquals("Invalid legal entity information provided", e.getError().getMessage());
             assertEquals(1, e.getError().getInvalidFields().size());
+        }
+    }
+
+    // test error parsing when the JSON response is invalid
+    @Test
+    public void testValidationExceptionWithInvalidJsonResponse() throws IOException {
+        Client client = createMockClientForErrors(422, "mocks/response-validation-error-invalid-json.json");
+
+        when(serviceMock.getClient()).thenReturn(client);
+        try {
+            Resource resource = new Resource(serviceMock, "", null);
+            resource.request("request");
+
+            fail("Expected exception");
+        } catch (ApiException e) {
+            assertEquals(422, e.getStatusCode());
+            assertNull(e.getError());
         }
     }
 }

--- a/src/test/resources/mocks/response-validation-error-invalid-json.json
+++ b/src/test/resources/mocks/response-validation-error-invalid-json.json
@@ -1,0 +1,9 @@
+{
+  "status" : 422,
+  "errorCode" : "130",
+  "message" : "Required field 'reference' is not provided.",
+  "errorType" : "validation",
+  "pspReference" : "ABCDEFGHIJKLMNO",
+  ...
+  // testing invalid JSON
+}


### PR DESCRIPTION
This PR improves the error handling by refactoring the code that creates the `ApiException`.

In the new approach, the API error (JSON) is parsed first to obtain all the error details, then the `ApiException` object is instantiated using a meaningful error message (instead of a default `HTTP Exception error` message.
