### PR TITLE
Configure HTTP Client connectionRequestTimeout

### DIFF
--- a/src/main/java/com/adyen/Config.java
+++ b/src/main/java/com/adyen/Config.java
@@ -18,7 +18,8 @@ public class Config {
     protected String apiKey;
     protected int connectionTimeoutMillis = 60 * 1000; // default 60 sec
     protected int readTimeoutMillis = 60 * 1000; // default 60 sec
-    protected int defaultKeepAlive = 60 * 1000; // default 60 sec
+    protected int connectionRequestTimeoutMillis = 60 * 1000; // default 60 sec
+    protected int defaultKeepAliveMillis = 60 * 1000; // default 60 sec
     protected Boolean protocolUpgradeEnabled;
 
     //Terminal API Specific
@@ -113,12 +114,20 @@ public class Config {
         this.readTimeoutMillis = readTimeoutMillis;
     }
 
-    public int getDefaultKeepAlive() {
-        return defaultKeepAlive;
+    public int getDefaultKeepAliveMillis() {
+        return defaultKeepAliveMillis;
     }
 
-    public void setDefaultKeepAlive(int defaultKeepAlive) {
-        this.defaultKeepAlive = defaultKeepAlive;
+    public void setDefaultKeepAliveMillis(int defaultKeepAliveMillis) {
+        this.defaultKeepAliveMillis = defaultKeepAliveMillis;
+    }
+
+    public int getConnectionRequestTimeoutMillis() {
+        return connectionRequestTimeoutMillis;
+    }
+
+    public void setConnectionRequestTimeoutMillis(int connectionRequestTimeoutMillis) {
+        this.connectionRequestTimeoutMillis = connectionRequestTimeoutMillis;
     }
 
     public Boolean getProtocolUpgradeEnabled() {

--- a/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
+++ b/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
@@ -118,7 +118,8 @@ public class AdyenHttpClient implements ClientInterface {
 
         builder.setResponseTimeout(config.getReadTimeoutMillis(), TimeUnit.MILLISECONDS);
         builder.setConnectTimeout(config.getConnectionTimeoutMillis(), TimeUnit.MILLISECONDS);
-        builder.setDefaultKeepAlive(config.getDefaultKeepAlive(), TimeUnit.MILLISECONDS);
+        builder.setDefaultKeepAlive(config.getDefaultKeepAliveMillis(), TimeUnit.MILLISECONDS);
+        builder.setConnectionRequestTimeout(config.getConnectionRequestTimeoutMillis(), TimeUnit.MILLISECONDS);
 
         if (config.getProtocolUpgradeEnabled() != null) {
             builder.setProtocolUpgradeEnabled(config.getProtocolUpgradeEnabled());


### PR DESCRIPTION
This PR makes `connectionRequestTimeout` setting configurable.

It also renames the configuration setting `defaultKeepAlive` to `defaultKeepAliveMillis` (this is not a breaking change as the new property was created during the development of this release and no yet published).

Fix #1460 