### PR TITLE
Rename Balance webhooks package

### DIFF
--- a/src/main/java/com/adyen/model/balancewebhooks/AbstractOpenApiSchema.java
+++ b/src/main/java/com/adyen/model/balancewebhooks/AbstractOpenApiSchema.java
@@ -10,7 +10,7 @@
  */
 
 
-package com.adyen.model.balanceplatformbalancewebhooks;
+package com.adyen.model.balancewebhooks;
 
 import java.util.Objects;
 import java.util.Map;

--- a/src/main/java/com/adyen/model/balancewebhooks/BalanceAccountBalanceNotificationRequest.java
+++ b/src/main/java/com/adyen/model/balancewebhooks/BalanceAccountBalanceNotificationRequest.java
@@ -10,12 +10,12 @@
  */
 
 
-package com.adyen.model.balanceplatformbalancewebhooks;
+package com.adyen.model.balancewebhooks;
 
 import java.util.Objects;
 import java.util.Map;
 import java.util.HashMap;
-import com.adyen.model.balanceplatformbalancewebhooks.BalanceNotificationData;
+import com.adyen.model.balancewebhooks.BalanceNotificationData;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/adyen/model/balancewebhooks/BalanceNotificationData.java
+++ b/src/main/java/com/adyen/model/balancewebhooks/BalanceNotificationData.java
@@ -10,12 +10,12 @@
  */
 
 
-package com.adyen.model.balanceplatformbalancewebhooks;
+package com.adyen.model.balancewebhooks;
 
 import java.util.Objects;
 import java.util.Map;
 import java.util.HashMap;
-import com.adyen.model.balanceplatformbalancewebhooks.Balances;
+import com.adyen.model.balancewebhooks.Balances;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/adyen/model/balancewebhooks/BalancePlatformNotificationResponse.java
+++ b/src/main/java/com/adyen/model/balancewebhooks/BalancePlatformNotificationResponse.java
@@ -10,7 +10,7 @@
  */
 
 
-package com.adyen.model.balanceplatformbalancewebhooks;
+package com.adyen.model.balancewebhooks;
 
 import java.util.Objects;
 import java.util.Map;

--- a/src/main/java/com/adyen/model/balancewebhooks/BalanceWebhooksHandler.java
+++ b/src/main/java/com/adyen/model/balancewebhooks/BalanceWebhooksHandler.java
@@ -9,19 +9,19 @@
  * Do not edit the class manually.
  */
 
-package com.adyen.model.balanceplatformbalancewebhooks;
+package com.adyen.model.balancewebhooks;
 
 import java.util.Optional;
 import java.util.logging.Logger;
 
 /**
- * Handler for processing BalancePlatformBalanceWebhooks.
+ * Handler for processing BalanceWebhooks.
  * <p>
- * This class provides functionality to deserialize the payload of BalancePlatformBalanceWebhooks events.
+ * This class provides functionality to deserialize the payload of BalanceWebhooks events.
  */
-public class BalancePlatformBalanceWebhooksHandler {
+public class BalanceWebhooksHandler {
 
-    private static final Logger LOG = Logger.getLogger(BalancePlatformBalanceWebhooksHandler.class.getName());
+    private static final Logger LOG = Logger.getLogger(BalanceWebhooksHandler.class.getName());
 
     private final String payload;
 
@@ -30,7 +30,7 @@ public class BalancePlatformBalanceWebhooksHandler {
      *
      * @param payload the raw JSON payload from the webhook
      */
-    public BalancePlatformBalanceWebhooksHandler(String payload) {
+    public BalanceWebhooksHandler(String payload) {
         this.payload = payload;
     }
 

--- a/src/main/java/com/adyen/model/balancewebhooks/Balances.java
+++ b/src/main/java/com/adyen/model/balancewebhooks/Balances.java
@@ -10,7 +10,7 @@
  */
 
 
-package com.adyen.model.balanceplatformbalancewebhooks;
+package com.adyen.model.balancewebhooks;
 
 import java.util.Objects;
 import java.util.Map;

--- a/src/main/java/com/adyen/model/balancewebhooks/JSON.java
+++ b/src/main/java/com/adyen/model/balancewebhooks/JSON.java
@@ -1,4 +1,4 @@
-package com.adyen.model.balanceplatformbalancewebhooks;
+package com.adyen.model.balancewebhooks;
 
 import com.adyen.serializer.ByteArraySerializer;
 import com.adyen.serializer.ByteArrayDeserializer;
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.adyen.model.balanceplatformbalancewebhooks.*;
+import com.adyen.model.balancewebhooks.*;
 
 import java.text.DateFormat;
 import java.util.HashMap;

--- a/src/test/java/com/adyen/BalancePlatformWebhooksTest.java
+++ b/src/test/java/com/adyen/BalancePlatformWebhooksTest.java
@@ -3,6 +3,8 @@ package com.adyen;
 import com.adyen.model.acswebhooks.AcsWebhooksHandler;
 import com.adyen.model.acswebhooks.AuthenticationNotificationRequest;
 import com.adyen.model.acswebhooks.RelayedAuthenticationRequest;
+import com.adyen.model.balancewebhooks.BalanceAccountBalanceNotificationRequest;
+import com.adyen.model.balancewebhooks.BalanceWebhooksHandler;
 import com.adyen.model.configurationwebhooks.*;
 import com.adyen.model.negativebalancewarningwebhooks.NegativeBalanceCompensationWarningNotificationRequest;
 import com.adyen.model.negativebalancewarningwebhooks.NegativeBalanceWarningWebhooksHandler;
@@ -201,4 +203,19 @@ public class BalancePlatformWebhooksTest extends BaseTest {
 
     }
 
+    @Test
+    public void tesBalanceAccountBalanceNotificationRequest() throws Exception {
+        String json = getFileContents("mocks/balancePlatform-webhooks/balanceplatform-balanceAccount-balance-updated.json");
+
+        Optional<BalanceAccountBalanceNotificationRequest> balanceAccountBalanceNotificationRequestOptional = new BalanceWebhooksHandler(json).getBalanceAccountBalanceNotificationRequest();
+        assertTrue(balanceAccountBalanceNotificationRequestOptional.isPresent());
+
+        BalanceAccountBalanceNotificationRequest balanceAccountBalanceNotificationRequest = balanceAccountBalanceNotificationRequestOptional.get();
+        assertNotNull(balanceAccountBalanceNotificationRequest.getData());
+
+        assertEquals("BWHS00000000000000000000000001", balanceAccountBalanceNotificationRequest.getData().getBalanceAccountId());
+        assertNotNull(balanceAccountBalanceNotificationRequest.getData().getBalances());
+        assertFalse(balanceAccountBalanceNotificationRequest.getData().getSettingIds().isEmpty());
+
+    }
 }

--- a/src/test/resources/mocks/balancePlatform-webhooks/balanceplatform-balanceAccount-balance-updated.json
+++ b/src/test/resources/mocks/balancePlatform-webhooks/balanceplatform-balanceAccount-balance-updated.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "balanceAccountId": "BWHS00000000000000000000000001",
+    "balancePlatform": "YOUR_BALANCE_PLATFORM",
+    "balances": {
+      "available": 499900,
+      "pending": 350000,
+      "reserved": 120000,
+      "balance": 470000
+    },
+    "creationDate": "2025-01-19T13:37:38+02:00",
+    "currency": "USD",
+    "settingIds": ["WK1", "WK2"]
+  },
+  "environment": "test",
+  "type": "balancePlatform.balanceAccount.balance.updated"
+}


### PR DESCRIPTION
PR to rename the [Balance webhooks](https://docs.adyen.com/api-explorer/balance-webhooks/1/overview) removing the `balancePlatform` prefix (this is not used by the other BP webhooks).