### PR TITLE
Avoid null in User-Agent header

### DIFF
--- a/src/main/java/com/adyen/Config.java
+++ b/src/main/java/com/adyen/Config.java
@@ -42,12 +42,22 @@ public class Config {
         this.username = username;
     }
 
+    public Config username(String username) {
+        this.username = username;
+        return this;
+    }
+
     public String getPassword() {
         return password;
     }
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public Config password(String password) {
+        this.password = password;
+        return this;
     }
 
     public Environment getEnvironment() {
@@ -58,12 +68,22 @@ public class Config {
         this.environment = environment;
     }
 
+    public Config environment(Environment environment) {
+        this.environment = environment;
+        return this;
+    }
+
     public String getApplicationName() {
         return applicationName;
     }
 
     public void setApplicationName(String applicationName) {
         this.applicationName = applicationName;
+    }
+
+    public Config applicationName(String applicationName) {
+        this.applicationName = applicationName;
+        return this;
     }
 
     public String getApiKey() {
@@ -74,12 +94,22 @@ public class Config {
         this.apiKey = apiKey;
     }
 
+    public Config apiKey(String apiKey) {
+        this.apiKey = apiKey;
+        return this;
+    }
+
     public String getTerminalApiCloudEndpoint() {
         return terminalApiCloudEndpoint;
     }
 
     public void setTerminalApiCloudEndpoint(String terminalApiCloudEndpoint) {
         this.terminalApiCloudEndpoint = terminalApiCloudEndpoint;
+    }
+
+    public Config terminalApiCloudEndpoint(String terminalApiCloudEndpoint) {
+        this.terminalApiCloudEndpoint = terminalApiCloudEndpoint;
+        return this;
     }
 
     public String getTerminalApiLocalEndpoint() {
@@ -90,12 +120,22 @@ public class Config {
         this.terminalApiLocalEndpoint = terminalApiLocalEndpoint;
     }
 
+    public Config terminalApiLocalEndpoint(String terminalApiLocalEndpoint) {
+        this.terminalApiLocalEndpoint = terminalApiLocalEndpoint;
+        return this;
+    }
+
     public Region getTerminalApiRegion() {
         return terminalApiRegion;
     }
 
     public void setTerminalApiRegion(Region terminalApiRegion) {
         this.terminalApiRegion = terminalApiRegion;
+    }
+
+    public Config terminalApiRegion(Region terminalApiRegion) {
+        this.terminalApiRegion = terminalApiRegion;
+        return this;
     }
 
     public int getConnectionTimeoutMillis() {
@@ -106,12 +146,22 @@ public class Config {
         this.connectionTimeoutMillis = connectionTimeoutMillis;
     }
 
+    public Config connectionTimeoutMillis(int connectionTimeoutMillis) {
+        this.connectionTimeoutMillis = connectionTimeoutMillis;
+        return this;
+    }
+
     public int getReadTimeoutMillis() {
         return readTimeoutMillis;
     }
 
     public void setReadTimeoutMillis(int readTimeoutMillis) {
         this.readTimeoutMillis = readTimeoutMillis;
+    }
+
+    public Config readTimeoutMillis(int readTimeoutMillis) {
+        this.readTimeoutMillis = readTimeoutMillis;
+        return this;
     }
 
     public int getDefaultKeepAliveMillis() {
@@ -122,12 +172,22 @@ public class Config {
         this.defaultKeepAliveMillis = defaultKeepAliveMillis;
     }
 
+    public Config defaultKeepAliveMillis(int defaultKeepAliveMillis) {
+        this.defaultKeepAliveMillis = defaultKeepAliveMillis;
+        return this;
+    }
+
     public int getConnectionRequestTimeoutMillis() {
         return connectionRequestTimeoutMillis;
     }
 
     public void setConnectionRequestTimeoutMillis(int connectionRequestTimeoutMillis) {
         this.connectionRequestTimeoutMillis = connectionRequestTimeoutMillis;
+    }
+
+    public Config connectionRequestTimeoutMillis(int connectionRequestTimeoutMillis) {
+        this.connectionRequestTimeoutMillis = connectionRequestTimeoutMillis;
+        return this;
     }
 
     public Boolean getProtocolUpgradeEnabled() {
@@ -142,11 +202,22 @@ public class Config {
         this.protocolUpgradeEnabled = protocolUpgradeEnabled;
     }
 
+    public Config protocolUpgradeEnabled(Boolean protocolUpgradeEnabled) {
+        this.protocolUpgradeEnabled = protocolUpgradeEnabled;
+        return this;
+    }
+
     public String getLiveEndpointUrlPrefix() {
         return this.liveEndpointUrlPrefix;
     }
+
     public void setLiveEndpointUrlPrefix(String liveEndpointUrlPrefix) {
         this.liveEndpointUrlPrefix = liveEndpointUrlPrefix;
+    }
+
+    public Config liveEndpointUrlPrefix(String liveEndpointUrlPrefix) {
+        this.liveEndpointUrlPrefix = liveEndpointUrlPrefix;
+        return this;
     }
 
     public SSLContext getSSLContext() {
@@ -162,6 +233,11 @@ public class Config {
         this.sslContext = sslContext;
     }
 
+    public Config sslContext(SSLContext sslContext) {
+        this.sslContext = sslContext;
+        return this;
+    }
+
     public HostnameVerifier getHostnameVerifier() {
         return hostnameVerifier;
     }
@@ -174,5 +250,10 @@ public class Config {
      */
     public void setHostnameVerifier(HostnameVerifier hostnameVerifier) {
         this.hostnameVerifier = hostnameVerifier;
+    }
+
+    public Config hostnameVerifier(HostnameVerifier hostnameVerifier) {
+        this.hostnameVerifier = hostnameVerifier;
+        return this;
     }
 }

--- a/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
+++ b/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
@@ -111,7 +111,7 @@ public class AdyenHttpClient implements ClientInterface {
         }
     }
 
-    private HttpUriRequestBase createRequest(String endpoint, String requestBody, Config config, boolean isApiKeyRequired, RequestOptions requestOptions, ApiConstants.HttpMethod httpMethod, Map<String, String> params) throws HTTPClientException {
+    HttpUriRequestBase createRequest(String endpoint, String requestBody, Config config, boolean isApiKeyRequired, RequestOptions requestOptions, ApiConstants.HttpMethod httpMethod, Map<String, String> params) throws HTTPClientException {
         HttpUriRequestBase httpRequest = createHttpRequestBase(createUri(endpoint, params), requestBody, httpMethod);
 
         RequestConfig.Builder builder = RequestConfig.custom();
@@ -140,7 +140,13 @@ public class AdyenHttpClient implements ClientInterface {
 
         setContentType(httpUriRequest, APPLICATION_JSON_TYPE);
         httpUriRequest.addHeader(ACCEPT_CHARSET, CHARSET);
-        httpUriRequest.addHeader(USER_AGENT, String.format("%s %s/%s", config.getApplicationName(), Client.LIB_NAME, Client.LIB_VERSION));
+
+        String applicationName = config.getApplicationName();
+        String userAgent = (applicationName != null && !applicationName.isBlank())
+                ? String.format("%s %s/%s", applicationName, Client.LIB_NAME, Client.LIB_VERSION)
+                : String.format("%s/%s", Client.LIB_NAME, Client.LIB_VERSION);
+        httpUriRequest.addHeader(USER_AGENT, userAgent);
+
         httpUriRequest.addHeader(ADYEN_LIBRARY_NAME, Client.LIB_NAME);
         httpUriRequest.addHeader(ADYEN_LIBRARY_VERSION, Client.LIB_VERSION);
 

--- a/src/test/java/com/adyen/httpclient/ClientTest.java
+++ b/src/test/java/com/adyen/httpclient/ClientTest.java
@@ -128,8 +128,7 @@ public class ClientTest extends BaseTest {
                 "https://chekout.adyen.com",
                 "{}",
                 new Config()
-                        .applicationName("test-app")
-                ,
+                        .applicationName("test-app"),
                 true,
                 null,
                 ApiConstants.HttpMethod.POST,
@@ -145,7 +144,7 @@ public class ClientTest extends BaseTest {
     public void testUserAgentWithoutApplicationName() throws Exception {
 
         AdyenHttpClient client = new AdyenHttpClient();
-        HttpUriRequestBase requestWithAppName = client.createRequest(
+        HttpUriRequestBase requestWithoutAppName = client.createRequest(
                 "https://chekout.adyen.com",
                 "{}",
                 new Config(),
@@ -155,7 +154,7 @@ public class ClientTest extends BaseTest {
                 Map.of()
         );
 
-        Header userAgent = requestWithAppName.getFirstHeader("User-Agent");
+        Header userAgent = requestWithoutAppName.getFirstHeader("User-Agent");
         assertNotNull(userAgent);
         assertEquals(Client.LIB_NAME + "/" + Client.LIB_VERSION, userAgent.getValue());
     }

--- a/src/test/java/com/adyen/httpclient/ClientTest.java
+++ b/src/test/java/com/adyen/httpclient/ClientTest.java
@@ -51,6 +51,7 @@ public class ClientTest extends BaseTest {
         config.setApiKey(apiKey);
         Client client = new Client(config);
         assertEquals(Environment.LIVE, client.getConfig().getEnvironment());
+        assertEquals("prefix", client.getConfig().getLiveEndpointUrlPrefix());
     }
 
     private static Stream<Arguments> provideCloudTestEndpointTestCases() {


### PR DESCRIPTION
PR that makes sure `User-Agent` header doesn't contain `null` when `applicationName` is undefined