### PR TITLE
Format GitHub action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,47 @@
+name: Java Code Format
+
+on:
+  push:
+    branches:
+      - 'sdk-automation/models'
+
+jobs:
+  format:
+    if: ${{ github.event.commits != null && !startsWith(github.event.head_commit.message, 'style(fmt)') }}
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '20'
+          distribution: 'adopt'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-
+
+      - name: Run Spotless Apply
+        run: mvn spotless:apply
+
+      - name: Commit and Push Changes
+        run: |
+          git config user.name AdyenAutomationBot
+          git config user.email "${{ secrets.ADYEN_AUTOMATION_BOT_EMAIL }}"
+          git add .
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "style(fmt): code formatted"
+            git push
+          fi

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -133,7 +133,9 @@
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
+        <!-- disable rule to align with Spotless formatting
         <module name="WhitespaceAround"/>
+        -->
 
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,37 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <!-- Format code -->
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.44.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <includes>
+                            <include>src/main/java/**/*.java</include>
+                            <include>src/test/java/**/*.java</include>
+                        </includes>
+                        <googleJavaFormat>
+                            <version>1.19.2</version>
+                            <style>GOOGLE</style>
+                            <formatJavadoc>true</formatJavadoc>
+                        </googleJavaFormat>
+                        <importOrder /> <!-- standard import order -->
+                        <removeUnusedImports>
+                            <engine>google-java-format</engine>
+                        </removeUnusedImports>
+                    </java>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
Add Maven Spotless Maven plugin to format the generated code.

Checkstyle configuration has been adjusted to align with Spotless formatting rules.