### PR TITLE
Local Terminal API: password hashing functions should use an unpredictable salt

### DIFF
--- a/src/main/java/com/adyen/terminal/security/NexoDerivedKeyGenerator.java
+++ b/src/main/java/com/adyen/terminal/security/NexoDerivedKeyGenerator.java
@@ -37,17 +37,18 @@ final class NexoDerivedKeyGenerator {
   private NexoDerivedKeyGenerator() {}
 
   /** Given a passphrase, compute 80 byte key of key material according to crypto.md */
-  static NexoDerivedKey deriveKeyMaterial(String passphrase)
+  static NexoDerivedKey deriveKeyMaterial(String passphrase, byte[] salt)
       throws NoSuchAlgorithmException, InvalidKeySpecException {
-    byte[] salt = "AdyenNexoV1Salt".getBytes();
+
     int iterations = 4000;
+    int keyLength = (NEXO_CIPHER_KEY_LENGTH + NEXO_HMAC_KEY_LENGTH + NEXO_IV_LENGTH) * 8;
 
     PBEKeySpec spec =
         new PBEKeySpec(
             passphrase.toCharArray(),
             salt,
             iterations,
-            (NEXO_CIPHER_KEY_LENGTH + NEXO_HMAC_KEY_LENGTH + NEXO_IV_LENGTH) * 8);
+            keyLength);
     SecretKeyFactory skf = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
     byte[] key = skf.generateSecret(spec).getEncoded();
 

--- a/src/test/java/com/adyen/terminal/security/NexoCryptoTest.java
+++ b/src/test/java/com/adyen/terminal/security/NexoCryptoTest.java
@@ -18,16 +18,17 @@
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  */
-package com.adyen;
+package com.adyen.terminal.security;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import com.adyen.BaseTest;
 import com.adyen.model.nexo.MessageHeader;
 import com.adyen.model.terminal.TerminalAPIRequest;
+import com.adyen.model.terminal.security.NexoDerivedKey;
 import com.adyen.model.terminal.security.SaleToPOISecuredMessage;
 import com.adyen.model.terminal.security.SecurityKey;
-import com.adyen.terminal.security.NexoCrypto;
 import com.adyen.terminal.security.exception.NexoCryptoException;
 import java.util.Random;
 import org.junit.BeforeClass;
@@ -96,5 +97,22 @@ public class NexoCryptoTest extends BaseTest {
     encryptedMessage.getSecurityTrailer().setHmac(modifiedHmac);
 
     nexoCrypto.decrypt(encryptedMessage);
+  }
+
+  @Test
+  public void getNexoDerivedKey() throws Exception {
+    NexoCrypto crypto = new NexoCrypto(testSecurityKey);
+    NexoDerivedKey key1 = crypto.getNexoDerivedKey();
+
+    assertNotNull(key1);
+  }
+
+  @Test
+  public void getNexoDerivedKey_shouldReturnSameInstance() throws Exception {
+    NexoCrypto crypto = new NexoCrypto(testSecurityKey);
+    NexoDerivedKey key1 = crypto.getNexoDerivedKey();
+    NexoDerivedKey key2 = crypto.getNexoDerivedKey();
+
+    assertEquals(key1, key2);
   }
 }

--- a/src/test/java/com/adyen/terminal/security/NexoCryptoTest.java
+++ b/src/test/java/com/adyen/terminal/security/NexoCryptoTest.java
@@ -21,6 +21,7 @@
 package com.adyen.terminal.security;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.adyen.BaseTest;
@@ -102,7 +103,7 @@ public class NexoCryptoTest extends BaseTest {
   @Test
   public void getNexoDerivedKey() throws Exception {
     NexoCrypto crypto = new NexoCrypto(testSecurityKey);
-    NexoDerivedKey key1 = crypto.getNexoDerivedKey();
+    NexoDerivedKey key1 = crypto.getNexoDerivedKey(crypto.getSalt());
 
     assertNotNull(key1);
   }
@@ -110,9 +111,19 @@ public class NexoCryptoTest extends BaseTest {
   @Test
   public void getNexoDerivedKey_shouldReturnSameInstance() throws Exception {
     NexoCrypto crypto = new NexoCrypto(testSecurityKey);
-    NexoDerivedKey key1 = crypto.getNexoDerivedKey();
-    NexoDerivedKey key2 = crypto.getNexoDerivedKey();
+    NexoDerivedKey key1 = crypto.getNexoDerivedKey(crypto.getSalt());
+    NexoDerivedKey key2 = crypto.getNexoDerivedKey(crypto.getSalt());
 
     assertEquals(key1, key2);
+  }
+
+  @Test
+  public void getNexoDerivedKey_fromDifferentInstances() throws Exception {
+    NexoCrypto crypto = new NexoCrypto(testSecurityKey);
+    NexoCrypto crypto2 = new NexoCrypto(testSecurityKey);
+    NexoDerivedKey key1 = crypto.getNexoDerivedKey(crypto.getSalt());
+    NexoDerivedKey key2 = crypto2.getNexoDerivedKey(crypto2.getSalt());
+
+    assertNotEquals(key1, key2);
   }
 }


### PR DESCRIPTION
Password hashing functions should use an unpredictable salt [java:S2053](https://sonarcloud.io/organizations/adyen/rules?open=java%3AS2053&rule_key=java%3AS2053).

This PR makes sure the library uses a random salt. 
