### PR TITLE
Maven Publishing Plugin: update configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
                     <publishingServerId>central</publishingServerId>
                     <tokenAuth>true</tokenAuth>
                     <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
+                    <waitUntil>validated</waitUntil>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The deploy to Maven Central was successful, but the pipeline [failed](https://github.com/Adyen/adyen-java-api-library/actions/runs/15701434786) because of timeout.
This PR updates the configuration of the GitHub action to wait until the package is `validated`. It will eventually be published after x minutes.