### PR TITLE
Maven publish: configure deploymentName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
                     <tokenAuth>true</tokenAuth>
                     <autoPublish>true</autoPublish>
                     <waitUntil>validated</waitUntil>
-                    <deploymentName>adyen-java-api-library</deploymentName>
+                    <deploymentName>${project.artifactId}</deploymentName>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Configure the name of the deployment that's used for uploading and deploying on the central url.
This is the name visible on the Deployments page.