### PR TITLE
Correct OneOf deserialization

### DIFF
--- a/templates-v7/libraries/jersey3/oneof_model.mustache
+++ b/templates-v7/libraries/jersey3/oneof_model.mustache
@@ -120,7 +120,10 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                 {{/isPrimitiveType}}
                 if (attemptParsing) {
                     // Checks if the unique type of the oneOf json matches any of the object TypeEnum values
-                    boolean typeMatch = Arrays.stream({{{dataType}}}.TypeEnum.values()).anyMatch((t) -> t.getValue().equals(tree.findValue("type").asText()));
+                    boolean typeMatch = false;
+                    if(tree.findValue("type") != null) {
+                        typeMatch = Arrays.stream({{{dataType}}}.TypeEnum.values()).anyMatch((t) -> t.getValue().equals(tree.findValue("type").asText()));
+                    }
 
                     if(typeMatch) {
                         {{#isMap}}


### PR DESCRIPTION
Following the fix #1539, this PR updates the Mustache templates to generate the expected deserialization code.