### PR TITLE
Validate location header 308

### DIFF
--- a/src/main/java/com/adyen/httpclient/AdyenCustomRedirectStrategy.java
+++ b/src/main/java/com/adyen/httpclient/AdyenCustomRedirectStrategy.java
@@ -1,0 +1,55 @@
+package com.adyen.httpclient;
+
+import java.net.URI;
+import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+/**
+ * Implements a custom redirect strategy when the API returns 308
+ */
+public class AdyenCustomRedirectStrategy extends DefaultRedirectStrategy {
+
+  /**
+   * Override getLocationURI to validate the location header
+   * @param request the request
+   * @param response the response
+   * @param context the context
+   * @return
+   * @throws HttpException an error has occurred
+   */
+  @Override
+  public URI getLocationURI(HttpRequest request, HttpResponse response, HttpContext context)
+      throws HttpException {
+    URI uri = super.getLocationURI(request, response, context);
+
+    int statusCode = response.getCode();
+    if (statusCode == 308) {
+      // validate 308 redirect
+      Header locationHeader = response.getFirstHeader("Location");
+      if (locationHeader == null) {
+        throw new HttpException("Redirect location is missing");
+      }
+      if (!isVerifyLocation(locationHeader.getValue())) {
+        throw new HttpException("Redirect location is invalid: " + locationHeader.getValue());
+      }
+    }
+
+    return uri;
+  }
+
+  /**
+   * True when location header is valid
+   *
+   * @param location Value of the location header
+   * @return true if valid
+   */
+  boolean isVerifyLocation(String location) {
+    location = location.toLowerCase();
+    return location.contains(".adyen.com") || location.contains(".adyenpayments.com");
+  }
+
+}

--- a/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
+++ b/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
@@ -261,6 +261,7 @@ public class AdyenHttpClient implements ClientInterface {
             PoolingHttpClientConnectionManagerBuilder.create()
                 .setSSLSocketFactory(socketFactory)
                 .build())
+        .setRedirectStrategy(new AdyenCustomRedirectStrategy())
         .build();
   }
 

--- a/src/test/java/com/adyen/httpclient/AdyenCustomRedirectStrategyTest.java
+++ b/src/test/java/com/adyen/httpclient/AdyenCustomRedirectStrategyTest.java
@@ -48,6 +48,13 @@ public class AdyenCustomRedirectStrategyTest {
   }
 
   @Test
+  public void testIsVerifyLocationMaliciousDomain() {
+    assertFalse(redirectStrategy.isVerifyLocation("https://adyen.com.evil.com"));
+    assertFalse(redirectStrategy.isVerifyLocation("https://evil.com?q=.adyen.com"));
+    assertFalse(redirectStrategy.isVerifyLocation("https://evil.com/.adyen.com"));
+  }
+
+  @Test
   public void testIsVerifyLocationEmpty() {
     assertFalse(redirectStrategy.isVerifyLocation(""));
   }
@@ -76,7 +83,7 @@ public class AdyenCustomRedirectStrategyTest {
   public void testGetLocationURI308InvadidDomainThrowsException() {
     when(response.getCode()).thenReturn(308);
     when(response.getFirstHeader("Location")).thenReturn(locationHeader);
-    String location = "https://test.example.com";
+    String location = "https://test.example.com/";
     when(locationHeader.getValue()).thenReturn(location);
 
     try {

--- a/src/test/java/com/adyen/httpclient/AdyenCustomRedirectStrategyTest.java
+++ b/src/test/java/com/adyen/httpclient/AdyenCustomRedirectStrategyTest.java
@@ -1,0 +1,90 @@
+package com.adyen.httpclient;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AdyenCustomRedirectStrategyTest {
+
+  private final AdyenCustomRedirectStrategy redirectStrategy = new AdyenCustomRedirectStrategy();
+
+  @Mock private HttpRequest request;
+  @Mock private HttpResponse response;
+  @Mock private HttpContext context;
+  @Mock private Header locationHeader;
+
+  @Test
+  public void testIsVerifyLocationAdyenDomain() {
+    assertTrue(redirectStrategy.isVerifyLocation("https://test.adyen.com/redirect"));
+  }
+
+  @Test
+  public void testIsVerifyLocationAdyenPaymentsDomain() {
+    assertTrue(redirectStrategy.isVerifyLocation("https://test.adyenpayments.com/redirect"));
+  }
+
+  @Test
+  public void testIsVerifyLocationMixedCase() {
+    assertTrue(redirectStrategy.isVerifyLocation("https://TEST.ADYEN.COM/redirect"));
+  }
+
+  @Test
+  public void testIsVerifyLocationInvalidDomain() {
+    assertFalse(redirectStrategy.isVerifyLocation("https://example.com/redirect"));
+  }
+
+  @Test
+  public void testIsVerifyLocationEmpty() {
+    assertFalse(redirectStrategy.isVerifyLocation(""));
+  }
+
+  @Test
+  public void testGetLocationURI308AdyenDomain() throws HttpException {
+    when(response.getCode()).thenReturn(308);
+    when(response.getFirstHeader("Location")).thenReturn(locationHeader);
+    when(locationHeader.getValue()).thenReturn("https://api.adyen.com");
+
+    URI uri = redirectStrategy.getLocationURI(request, response, context);
+    assertEquals("https://api.adyen.com/", uri.toString());
+  }
+
+  @Test
+  public void testGetLocationURI308AdyenPaymentsDomain() throws HttpException {
+    when(response.getCode()).thenReturn(308);
+    when(response.getFirstHeader("Location")).thenReturn(locationHeader);
+    when(locationHeader.getValue()).thenReturn("https://api.adyenpayments.com");
+
+    URI uri = redirectStrategy.getLocationURI(request, response, context);
+    assertEquals("https://api.adyenpayments.com/", uri.toString());
+  }
+
+  @Test
+  public void testGetLocationURI308InvadidDomainThrowsException() {
+    when(response.getCode()).thenReturn(308);
+    when(response.getFirstHeader("Location")).thenReturn(locationHeader);
+    String location = "https://test.example.com";
+    when(locationHeader.getValue()).thenReturn(location);
+
+    try {
+      redirectStrategy.getLocationURI(request, response, context);
+      fail("Expected HttpException was not thrown");
+    } catch (HttpException e) {
+      assertEquals("Redirect location is invalid: " + location, e.getMessage());
+    }
+  }
+
+}


### PR DESCRIPTION
The Terminal API returns `308` response status when the incorrect region is used. The Java library handles the `308` by redirecting to the endpoint returned in the location header.

This PR introduces a validation that ensures the url is part of `adyen.com` or `adyenpayments.com`