### PR TITLE
Correct LIVE url for SessionAuthentication API

### DIFF
--- a/src/main/java/com/adyen/Service.java
+++ b/src/main/java/com/adyen/Service.java
@@ -89,6 +89,10 @@ public class Service {
       return url.replaceFirst("-live", "-test");
     }
 
+    if (url.contains("/authe/")) {
+      return url.replaceFirst("https://test.adyen.com/", "https://authe-live.adyen.com/");
+    }
+
     if (url.contains("pal-")) {
       if (config.getLiveEndpointUrlPrefix() == null) {
         throw new IllegalArgumentException("please provide a live url prefix in the client");

--- a/src/test/java/com/adyen/ServiceTest.java
+++ b/src/test/java/com/adyen/ServiceTest.java
@@ -92,4 +92,13 @@ public class ServiceTest extends BaseTest {
     String actualUrl = service.createBaseURL(testUrl);
     assertEquals(expectedUrl, actualUrl);
   }
+
+  @Test
+  public void testSessionAuthenticationLiveUrl() {
+    String testUrl = "https://test.adyen.com/authe/api/v1";
+    String expectedUrl = "https://authe-live.adyen.com/authe/api/v1";
+
+    String actualUrl = service.createBaseURL(testUrl);
+    assertEquals(expectedUrl, actualUrl);
+  }
 }


### PR DESCRIPTION
The `live` url of the [SessionAuthentication](https://docs.adyen.com/api-explorer/sessionauthentication/1/overview) API is incorrect: this PR fixes the bug and adds a test.

This is a short-term solution, we will revise the approach and use the url from the OpenAPI `servers` element.

Fix #1577 
