### PR TITLE
fix(ci): ensure release workflow triggers only on merged requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
-name: Release
+name: Automated Release Preparation
 
+# This workflow runs automatically when a pull request is merged into the main branch.
+# It prepares the next release by creating or updating a "Release PR" with the new version and changelog.
+# The final release publication, which triggers the 'publish.yml' workflow, happens when that "Release PR" is merged.
 on:
   workflow_dispatch:
     inputs:
@@ -25,12 +28,16 @@ permissions:
 
 jobs:
   release:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # 1. Allow manual dispatch
+    # 2. OR (If it's a PR, it must be merged AND from the same repository)
+    if: |
+      github.event_name == 'workflow_dispatch' || 
+      (github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Prepare the next main release
-        uses: Adyen/release-automation-action@596a5a3a2d677ec5329c916d7a4628f8045a5585
+        uses: Adyen/release-automation-action@3e5694d5b365f344a62436e84049511ef318ecf5
         with:
           token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
           develop-branch: main


### PR DESCRIPTION
This pull request fixes an issue in the release workflow that could cause it to trigger on any closed or merged pull request. The workflow has been updated to ensure that releases are only triggered when a pull request is merged.