### PR TITLE
FIX check for required query parameters for services

### DIFF
--- a/templates-v7/libraries/jersey3/api.mustache
+++ b/templates-v7/libraries/jersey3/api.mustache
@@ -70,10 +70,24 @@ public class {{classname}} extends Service {
         {{#hasQueryParams}}
         //Add query params
         Map<String, String> queryParams = new HashMap<>();
+
+        {{! Add first all required query params }}
         {{#queryParams}}
-        if ({{{paramName}}} != null) {
-        queryParams.put("{{baseName}}", {{{paramName}}}{{^isString}}.toString(){{/isString}});
+        {{#required}}
+        if ({{{paramName}}} == null) {
+            throw new IllegalArgumentException("Please provide the {{{paramName}}} query parameter");
         }
+        queryParams.put("{{baseName}}", {{{paramName}}}{{^isString}}.toString(){{/isString}});
+        {{/required}}
+        {{/queryParams}}
+
+        {{! Then, add all the optional query params }}
+        {{#queryParams}}
+        {{^required}}
+        if ({{{paramName}}} != null) {
+            queryParams.put("{{baseName}}", {{{paramName}}}{{^isString}}.toString(){{/isString}});
+        }
+        {{/required}}
         {{/queryParams}}
 
         {{/hasQueryParams}}


### PR DESCRIPTION

**Description**

The current template does not enforce the presence of required query parameters. The change in the template allows to throw a runtime exception for missing required parameters. Optional query params are added next to the required params with the existing null check.

**Tested scenarios**

- Changed the /grants endpoint from `CapitalService-v1.json` spec with a sequence of required/optional query params and re-generated the code.

**Fixed issue**:  <!-- #-prefixed issue number -->

- relates to the merge of Capital: https://github.com/Adyen/adyen-java-api-library/pull/1664#discussion_r2694666570
