### PR TITLE
FIX add Java 21 to CI version matrix

### DIFF
--- a/.github/workflows/javaci.yml
+++ b/.github/workflows/javaci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165
         with:
-          java-version: '20'
+          java-version: '21'
           distribution: 'adopt'
       - name: Cache Maven packages
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '11', '17', '20' ]
+        java: [ '11', '17', '20', '21' ]
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd


### PR DESCRIPTION
**Description**
Adds Java 21 to the CI version matrix

**Tested scenarios**
- N/A

**Fixed issue**:
- N/A
