### PR TITLE
Revert "Remove redundant secret exposure in Maven publish workflow"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,3 +34,7 @@ jobs:
 
     - name: Publish to Apache Maven Central
       run: mvn deploy
+      env:
+        MAVEN_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME}}
+        MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}


### PR DESCRIPTION
This reverts commit 18321561cdf58f5803e824f2cc051a433afd9873.

Publishing pipeline is broken. There were only two PRs after the last successful publishing:
- 18321561cdf58f5803e824f2cc051a433afd9873
- e456038ad7ea999fe6544040a282a652c8f3d6a1

It's likely that the latest from Copilot caused the issue.