### PR TITLE
fix(ci): enable workflow dispatch for publishing artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish package to the Maven Central Repository
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
This allows us to trigger manually the publishing workflow at any particular branch/revision in git history. Other libraries use this as well.