### PR TITLE
Add merge_group to javaci workflow

### DIFF
--- a/.github/workflows/javaci.yml
+++ b/.github/workflows/javaci.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
     branches:
       - main
-      - sdk-automation/models
       - promote/main
+  merge_group:    
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the workflow triggers in `.github/workflows/javaci.yml`. The change removes the `sdk-automation/models` branch from the list of branches that trigger the workflow on pull requests and adds a new trigger for `merge_group` events.

This is necessary to trigger the GitHub Actions workflow when a pull request is added to a merge queue.

See GitHub [doc](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) 

