### PR TITLE
(feature) - update unit testing framework to Junit 5 and migrate existing tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <swagger-core-version>1.6.16</swagger-core-version>
         <sonar.organization>adyen</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <junit-jupiter-version>5.11.4</junit-jupiter-version>
     </properties>
     <scm>
         <connection>scm:git:git@github.com:Adyen/adyen-java-api-library.git</connection>
@@ -239,16 +240,29 @@
             <version>5.5</version>
             <scope>compile</scope>
         </dependency>
+
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.15.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>5.15.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -292,12 +306,6 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>5.14.1</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/com/adyen/ApplicationInfoTest.java
+++ b/src/test/java/com/adyen/ApplicationInfoTest.java
@@ -2,11 +2,11 @@ package com.adyen;
 
 import static com.adyen.Client.LIB_NAME;
 import static com.adyen.Client.LIB_VERSION;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.adyen.model.applicationinfo.ApplicationInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ApplicationInfoTest {
 

--- a/src/test/java/com/adyen/BalanceControlTest.java
+++ b/src/test/java/com/adyen/BalanceControlTest.java
@@ -1,6 +1,6 @@
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 
 import com.adyen.constants.ApiConstants;
@@ -11,7 +11,7 @@ import com.adyen.service.balancecontrol.BalanceControlApi;
 import com.adyen.service.exception.ApiException;
 import java.io.IOException;
 import java.time.OffsetDateTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BalanceControlTest extends BaseTest {
 

--- a/src/test/java/com/adyen/BalancePlatformTest.java
+++ b/src/test/java/com/adyen/BalancePlatformTest.java
@@ -2,7 +2,7 @@ package com.adyen;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class BalancePlatformTest extends BaseTest {

--- a/src/test/java/com/adyen/BaseTest.java
+++ b/src/test/java/com/adyen/BaseTest.java
@@ -22,7 +22,7 @@ package com.adyen;
 
 import static com.adyen.Client.LIB_NAME;
 import static com.adyen.Client.LIB_VERSION;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/adyen/BinLookupTest.java
+++ b/src/test/java/com/adyen/BinLookupTest.java
@@ -20,15 +20,15 @@
  */
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.adyen.model.binlookup.*;
 import com.adyen.service.binlookup.BinLookupApi;
 import com.adyen.service.exception.ApiException;
 import java.util.ArrayList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for /get3dsAvailability /getCostEstimate */
 public class BinLookupTest extends BaseTest {

--- a/src/test/java/com/adyen/CheckoutTest.java
+++ b/src/test/java/com/adyen/CheckoutTest.java
@@ -20,7 +20,7 @@
  */
 package com.adyen;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 
@@ -32,8 +32,8 @@ import com.adyen.service.checkout.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.time.OffsetDateTime;
 import java.util.*;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class CheckoutTest extends BaseTest {
@@ -385,8 +385,8 @@ public class CheckoutTest extends BaseTest {
     RecurringApi checkout = new RecurringApi(client);
     ListStoredPaymentMethodsResponse response =
         checkout.getTokensForStoredPaymentDetails("test-1234", "TestMerchantAccount", null);
-    Assert.assertEquals("merchantAccount", response.getMerchantAccount());
-    Assert.assertEquals("string", response.getStoredPaymentMethods().get(0).getBrand());
+    Assertions.assertEquals("merchantAccount", response.getMerchantAccount());
+    Assertions.assertEquals("string", response.getStoredPaymentMethods().get(0).getBrand());
   }
 
   /** Should delete StoredPaymentMethods */
@@ -478,10 +478,10 @@ public class CheckoutTest extends BaseTest {
                 + "    \"applePayToken\": \"VNRWtuNlNEWkRCSm1xWndjMDFFbktkQU...\"\n"
                 + "  }");
 
-    Assert.assertTrue(checkoutPaymentMethodGoogle.toJson().contains("paywithgoogle"));
-    Assert.assertTrue(checkoutPaymentMethodGoogle.toJson().contains("googlePayToken"));
-    Assert.assertTrue(checkoutPaymentMethodScheme.toJson().contains("scheme"));
-    Assert.assertTrue(
+    Assertions.assertTrue(checkoutPaymentMethodGoogle.toJson().contains("paywithgoogle"));
+    Assertions.assertTrue(checkoutPaymentMethodGoogle.toJson().contains("googlePayToken"));
+    Assertions.assertTrue(checkoutPaymentMethodScheme.toJson().contains("scheme"));
+    Assertions.assertTrue(
         checkoutPaymentMethodApple.toJson().contains("NRWtuNlNEWkRCSm1xWndjMDFFbktkQU"));
   }
 

--- a/src/test/java/com/adyen/DataProtectionServiceTest.java
+++ b/src/test/java/com/adyen/DataProtectionServiceTest.java
@@ -20,7 +20,7 @@
  */
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 
 import com.adyen.constants.ApiConstants;
@@ -29,7 +29,7 @@ import com.adyen.model.dataprotection.SubjectErasureResponse;
 import com.adyen.service.dataprotection.DataProtectionApi;
 import com.adyen.service.exception.ApiException;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DataProtectionServiceTest extends BaseTest {
   /** Test success flow for POST /requestSubjectErasure */

--- a/src/test/java/com/adyen/DateSerializationTest.java
+++ b/src/test/java/com/adyen/DateSerializationTest.java
@@ -13,7 +13,7 @@ import com.adyen.service.checkout.PaymentsApi;
 import com.adyen.service.exception.ApiException;
 import java.io.IOException;
 import java.time.OffsetDateTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class DateSerializationTest extends BaseTest {

--- a/src/test/java/com/adyen/DisputesTest.java
+++ b/src/test/java/com/adyen/DisputesTest.java
@@ -1,6 +1,6 @@
 package com.adyen;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 
 import com.adyen.constants.ApiConstants;
@@ -11,7 +11,7 @@ import com.adyen.service.disputes.DisputesApi;
 import com.adyen.service.exception.ApiException;
 import java.io.IOException;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DisputesTest extends BaseTest {
 

--- a/src/test/java/com/adyen/ErrorHandlingTest.java
+++ b/src/test/java/com/adyen/ErrorHandlingTest.java
@@ -7,13 +7,13 @@ import com.adyen.service.checkout.PaymentLinksApi;
 import com.adyen.service.exception.ApiException;
 import com.adyen.service.management.MyApiCredentialApi;
 import java.io.IOException;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ErrorHandlingTest extends BaseTest {
   @Test
-  @Ignore("Integration test")
+  @Disabled("Integration test")
   public void addAllowedOriginFail() throws IOException, ApiException {
     Client client = new Client(System.getenv("API_KEY"), Environment.TEST);
     MyApiCredentialApi service = new MyApiCredentialApi(client);
@@ -23,23 +23,23 @@ public class ErrorHandlingTest extends BaseTest {
     try {
       service.addAllowedOrigin(createAllowedOriginRequest);
     } catch (ApiException e) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           e.getResponseBody().contains("Invalid allowed origin information provided."));
     }
   }
 
   @Test
-  @Ignore("Integration test")
+  @Disabled("Integration test")
   public void CheckoutErrorTest() throws IOException, ApiException {
     Client client = new Client(System.getenv("API_KEY"), Environment.TEST);
     PaymentLinksApi service = new PaymentLinksApi(client);
     try {
       service.getPaymentLink("1234");
     } catch (ApiException e) {
-      Assert.assertTrue(e.getResponseBody().contains("Invalid payment link ID"));
+      Assertions.assertTrue(e.getResponseBody().contains("Invalid payment link ID"));
       ApiError apiError = e.getError();
-      Assert.assertEquals("Validation", apiError.getErrorType());
-      Assert.assertEquals("Invalid payment link ID", apiError.getMessage());
+      Assertions.assertEquals("Validation", apiError.getErrorType());
+      Assertions.assertEquals("Invalid payment link ID", apiError.getMessage());
     }
   }
 }

--- a/src/test/java/com/adyen/LegalEntityManagementTest.java
+++ b/src/test/java/com/adyen/LegalEntityManagementTest.java
@@ -1,6 +1,6 @@
 package com.adyen;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 
 import com.adyen.constants.ApiConstants;
@@ -11,8 +11,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.codec.binary.Base64;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LegalEntityManagementTest extends BaseTest {
   @Test
@@ -475,7 +475,7 @@ public class LegalEntityManagementTest extends BaseTest {
                   + "  \"paramNotInSpec\":false\n "
                   + "}");
     } catch (Exception ex) {
-      Assert.fail();
+      Assertions.fail();
     }
   }
 }

--- a/src/test/java/com/adyen/ManagementTest.java
+++ b/src/test/java/com/adyen/ManagementTest.java
@@ -1,6 +1,6 @@
 package com.adyen;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 
 import com.adyen.constants.ApiConstants;
@@ -12,8 +12,8 @@ import com.adyen.service.management.*;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ManagementTest extends BaseTest {
   @Test
@@ -122,7 +122,7 @@ public class ManagementTest extends BaseTest {
   }
 
   @Test
-  @Ignore("Integration test")
+  @Disabled("Integration test")
   public void me() throws IOException, ApiException {
     Client client = new Client(System.getenv("API_KEY"), Environment.TEST);
     MyApiCredentialApi service = new MyApiCredentialApi(client);

--- a/src/test/java/com/adyen/MarketPayTest.java
+++ b/src/test/java/com/adyen/MarketPayTest.java
@@ -1,6 +1,6 @@
 package com.adyen;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 
 import com.adyen.constants.ApiConstants;
@@ -25,7 +25,7 @@ import com.adyen.service.classicplatforms.ClassicPlatformFundApi;
 import com.adyen.service.classicplatforms.ClassicPlatformHopApi;
 import com.adyen.service.exception.ApiException;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MarketPayTest extends BaseTest {
 

--- a/src/test/java/com/adyen/NexoCryptoTest.java
+++ b/src/test/java/com/adyen/NexoCryptoTest.java
@@ -20,8 +20,9 @@
  */
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.adyen.model.nexo.MessageHeader;
 import com.adyen.model.terminal.TerminalAPIRequest;
@@ -30,15 +31,15 @@ import com.adyen.model.terminal.security.SecurityKey;
 import com.adyen.terminal.security.NexoCrypto;
 import com.adyen.terminal.security.exception.NexoCryptoException;
 import java.util.Random;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /** Tests for Nexo encryption/decryption */
 public class NexoCryptoTest extends BaseTest {
 
   private static SecurityKey testSecurityKey;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     testSecurityKey = new SecurityKey();
     testSecurityKey.setKeyVersion(1);
@@ -76,12 +77,12 @@ public class NexoCryptoTest extends BaseTest {
     assertEquals(requestJson, decryptedMessage);
   }
 
-  @Test(expected = NexoCryptoException.class)
-  public void testEncryptionWithInvalidSecurityKey() throws Exception {
-    new NexoCrypto(new SecurityKey());
+  @Test
+  public void testEncryptionWithInvalidSecurityKey() {
+    assertThrows(NexoCryptoException.class, () -> new NexoCrypto(new SecurityKey()));
   }
 
-  @Test(expected = NexoCryptoException.class)
+  @Test
   public void testDecryptionWithInvalidHmac() throws Exception {
     TerminalAPIRequest terminalAPIRequest = createTerminalAPIPaymentRequest();
     MessageHeader messageHeader = terminalAPIRequest.getSaleToPOIRequest().getMessageHeader();
@@ -95,6 +96,6 @@ public class NexoCryptoTest extends BaseTest {
     new Random().nextBytes(modifiedHmac);
     encryptedMessage.getSecurityTrailer().setHmac(modifiedHmac);
 
-    nexoCrypto.decrypt(encryptedMessage);
+    assertThrows(NexoCryptoException.class, () -> nexoCrypto.decrypt(encryptedMessage));
   }
 }

--- a/src/test/java/com/adyen/OpenBankingTest.java
+++ b/src/test/java/com/adyen/OpenBankingTest.java
@@ -1,7 +1,7 @@
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -12,7 +12,7 @@ import com.adyen.model.openbanking.AccountVerificationReportResponse;
 import com.adyen.model.openbanking.AccountVerificationRoutesRequest;
 import com.adyen.model.openbanking.AccountVerificationRoutesResponse;
 import com.adyen.service.openbanking.AccountVerificationApi;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OpenBankingTest extends BaseTest {
 

--- a/src/test/java/com/adyen/PaymentTest.java
+++ b/src/test/java/com/adyen/PaymentTest.java
@@ -23,7 +23,7 @@ package com.adyen;
 import static com.adyen.constants.ApiConstants.AdditionalData.*;
 import static com.adyen.constants.ApiConstants.SelectedBrand.BOLETO_SANTANDER;
 import static com.adyen.model.payment.PaymentResult.ResultCodeEnum.RECEIVED;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.adyen.constants.ApiConstants.AdditionalData;
@@ -46,7 +46,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import okio.ByteString;
 import org.apache.commons.codec.binary.Base64;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for /authorise and /authorise3d */
 public class PaymentTest extends BaseTest {

--- a/src/test/java/com/adyen/PaymentsAppTest.java
+++ b/src/test/java/com/adyen/PaymentsAppTest.java
@@ -1,9 +1,9 @@
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.adyen.model.RequestOptions;
 import com.adyen.model.paymentsapp.BoardingTokenRequest;
@@ -11,7 +11,7 @@ import com.adyen.model.paymentsapp.BoardingTokenResponse;
 import com.adyen.model.paymentsapp.PaymentsAppResponse;
 import com.adyen.service.exception.ApiException;
 import com.adyen.service.paymentsapp.PaymentsAppApi;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PaymentsAppTest extends BaseTest {
 

--- a/src/test/java/com/adyen/PayoutTest.java
+++ b/src/test/java/com/adyen/PayoutTest.java
@@ -22,17 +22,17 @@ package com.adyen;
 
 import static com.adyen.constants.ApiConstants.AdditionalData.FRAUD_MANUAL_REVIEW;
 import static com.adyen.constants.ApiConstants.AdditionalData.FRAUD_RESULT_TYPE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.adyen.model.payout.*;
 import com.adyen.service.exception.ApiException;
 import com.adyen.service.payout.InitializationApi;
 import com.adyen.service.payout.InstantPayoutsApi;
 import com.adyen.service.payout.ReviewingApi;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PayoutTest extends BaseTest {
 

--- a/src/test/java/com/adyen/PosPaymentTest.java
+++ b/src/test/java/com/adyen/PosPaymentTest.java
@@ -20,16 +20,16 @@
  */
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.adyen.model.terminal.ConnectedTerminalsRequest;
 import com.adyen.model.terminal.ConnectedTerminalsResponse;
 import com.adyen.service.PosPayment;
 import com.adyen.service.exception.ApiException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PosPaymentTest extends BaseTest {
 

--- a/src/test/java/com/adyen/PosTerminalManagementTest.java
+++ b/src/test/java/com/adyen/PosTerminalManagementTest.java
@@ -21,13 +21,13 @@
 
 package com.adyen;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.adyen.model.posterminalmanagement.*;
 import com.adyen.service.PosTerminalManagementApi;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PosTerminalManagementTest extends BaseTest {
 

--- a/src/test/java/com/adyen/RecurringTest.java
+++ b/src/test/java/com/adyen/RecurringTest.java
@@ -4,11 +4,11 @@
  */
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.adyen.model.recurring.*;
 import com.adyen.service.exception.ApiException;
@@ -18,7 +18,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RecurringTest extends BaseTest {
   private RecurringDetailsRequest createRecurringDetailsRequest() {

--- a/src/test/java/com/adyen/RegionTest.java
+++ b/src/test/java/com/adyen/RegionTest.java
@@ -1,12 +1,12 @@
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.adyen.enums.Region;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RegionTest {
   @Test

--- a/src/test/java/com/adyen/ServiceTest.java
+++ b/src/test/java/com/adyen/ServiceTest.java
@@ -1,10 +1,10 @@
 package com.adyen;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.adyen.enums.Environment;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link Service#createBaseURL(String)}. */
 public class ServiceTest extends BaseTest {
@@ -12,7 +12,7 @@ public class ServiceTest extends BaseTest {
   private Config config;
   private Service service;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     config = new Config().environment(Environment.LIVE);
     Client client = new Client(config);

--- a/src/test/java/com/adyen/SessionAuthenticationTest.java
+++ b/src/test/java/com/adyen/SessionAuthenticationTest.java
@@ -1,13 +1,13 @@
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 
 import com.adyen.constants.ApiConstants;
 import com.adyen.model.sessionauthentication.*;
 import com.adyen.service.sessionauthentication.SessionAuthenticationApi;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SessionAuthenticationTest extends BaseTest {
 

--- a/src/test/java/com/adyen/StoredValueTest.java
+++ b/src/test/java/com/adyen/StoredValueTest.java
@@ -35,9 +35,9 @@
 // import com.adyen.model.storedvalue.StoredValueVoidRequest;
 // import com.adyen.model.storedvalue.StoredValueVoidResponse;
 // import com.adyen.service.StoredValue;
-// import org.junit.Test;
+// import org.junit.jupiter.api.Test;
 //
-// import static org.junit.Assert.*;
+// import static org.junit.jupiter.api.Assertions.*;
 //
 /// **
 // * Tests for

--- a/src/test/java/com/adyen/TerminalCloudAPITest.java
+++ b/src/test/java/com/adyen/TerminalCloudAPITest.java
@@ -20,7 +20,7 @@
  */
 package com.adyen;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -49,7 +49,7 @@ import com.adyen.model.terminal.TerminalAPIResponse;
 import com.adyen.service.TerminalCloudAPI;
 import java.math.BigDecimal;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 /** Tests for /sync and /async */
@@ -186,9 +186,9 @@ public class TerminalCloudAPITest extends BaseTest {
 
     String requestAsJson = captor.getValue();
     assertTrue(
-        "SaleToAcquirerData field not found", requestAsJson.contains("\"SaleToAcquirerData\":"));
-    assertFalse("Found null value", requestAsJson.contains(":null"));
-    assertFalse("Found null value", requestAsJson.contains(": null"));
+        requestAsJson.contains("\"SaleToAcquirerData\":"), "SaleToAcquirerData field not found");
+    assertFalse(requestAsJson.contains(":null"), "Found null value");
+    assertFalse(requestAsJson.contains(": null"), "Found null value");
   }
 
   /** Test success flow for POST /sync that includes unexpected attributes */
@@ -292,11 +292,11 @@ public class TerminalCloudAPITest extends BaseTest {
             isNull());
 
     String requestAsJson = captor.getValue();
-    assertTrue("InputRequest field not found", requestAsJson.contains("\"InputRequest\":"));
+    assertTrue(requestAsJson.contains("\"InputRequest\":"), "InputRequest field not found");
     assertTrue(
-        "PredefinedContent field not found", requestAsJson.contains("\"PredefinedContent\":"));
-    assertFalse("Found null value", requestAsJson.contains(":null"));
-    assertFalse("Found null value", requestAsJson.contains(": null"));
+        requestAsJson.contains("\"PredefinedContent\":"), "PredefinedContent field not found");
+    assertFalse(requestAsJson.contains(":null"), "Found null value");
+    assertFalse(requestAsJson.contains(": null"), "Found null value");
   }
 
   /** Mocked response for stored value type for POST /sync */

--- a/src/test/java/com/adyen/TerminalLocalAPITest.java
+++ b/src/test/java/com/adyen/TerminalLocalAPITest.java
@@ -20,7 +20,7 @@
  */
 package com.adyen;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.adyen.model.nexo.MessageCategoryType;
 import com.adyen.model.nexo.MessageClassType;
@@ -42,7 +42,7 @@ import com.adyen.model.terminal.security.SecurityKey;
 import com.adyen.service.TerminalLocalAPI;
 import java.math.BigDecimal;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for local Terminal API request */
 public class TerminalLocalAPITest extends BaseTest {

--- a/src/test/java/com/adyen/TransfersTest.java
+++ b/src/test/java/com/adyen/TransfersTest.java
@@ -1,13 +1,13 @@
 package com.adyen;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 
 import com.adyen.constants.ApiConstants;
 import com.adyen.model.transfers.*;
 import com.adyen.service.transfers.*;
 import java.util.HashMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransfersTest extends BaseTest {
 

--- a/src/test/java/com/adyen/UtilTest.java
+++ b/src/test/java/com/adyen/UtilTest.java
@@ -1,9 +1,10 @@
 package com.adyen;
 
 import static com.adyen.constants.ApiConstants.AdditionalData.HMAC_SIGNATURE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.adyen.model.notification.Amount;
 import com.adyen.model.notification.NotificationRequestItem;
@@ -14,7 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for Util class */
 public class UtilTest {
@@ -73,12 +74,12 @@ public class UtilTest {
     assertFalse(hmacValidator.validateHMAC(notificationRequestItem, key));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testValidateHMACException() throws SignatureException {
+  @Test
+  public void testValidateHMACException() {
     NotificationRequestItem notificationRequestItem = new NotificationRequestItem();
     HMACValidator hmacValidator = new HMACValidator();
     String key = "DFB1EB5485895CFA84146406857104ABB4CBCABDC8AAF103A624C8F6A3EAAB00";
-    hmacValidator.validateHMAC(notificationRequestItem, key);
+    assertThrows(IllegalArgumentException.class, () -> hmacValidator.validateHMAC(notificationRequestItem, key));
   }
 
   @Test

--- a/src/test/java/com/adyen/builders/terminal/TerminalAPIRequestBuilderTest.java
+++ b/src/test/java/com/adyen/builders/terminal/TerminalAPIRequestBuilderTest.java
@@ -21,22 +21,23 @@
 
 package com.adyen.builders.terminal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.adyen.model.nexo.MessageCategoryType;
 import com.adyen.model.nexo.MessageClassType;
 import com.adyen.model.nexo.PaymentRequest;
 import com.adyen.model.nexo.TransactionStatusRequest;
 import com.adyen.model.terminal.TerminalAPIRequest;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
+import org.mockito.Mock;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class TerminalAPIRequestBuilderTest {
 
   private TerminalAPIRequestBuilder terminalAPIRequestBuilder;
@@ -48,7 +49,7 @@ public class TerminalAPIRequestBuilderTest {
   private final String SERVICE_ID = "test-service-id";
   private final String POI_ID = "test-poi";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     terminalAPIRequestBuilder = new TerminalAPIRequestBuilder(SALE_ID, SERVICE_ID, POI_ID);
   }

--- a/src/test/java/com/adyen/httpclient/AdyenCustomRedirectStrategyTest.java
+++ b/src/test/java/com/adyen/httpclient/AdyenCustomRedirectStrategyTest.java
@@ -1,9 +1,9 @@
 package com.adyen.httpclient;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
@@ -12,12 +12,13 @@ import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
+import org.mockito.Mock;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class AdyenCustomRedirectStrategyTest {
 
   private final AdyenCustomRedirectStrategy redirectStrategy = new AdyenCustomRedirectStrategy();

--- a/src/test/java/com/adyen/httpclient/ClientTest.java
+++ b/src/test/java/com/adyen/httpclient/ClientTest.java
@@ -1,6 +1,6 @@
 package com.adyen.httpclient;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.adyen.BaseTest;
 import com.adyen.Client;
@@ -15,8 +15,8 @@ import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.core5.http.Header;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -118,7 +118,7 @@ public class ClientTest extends BaseTest {
     config.setEnvironment(Environment.LIVE);
     config.setTerminalApiRegion(Region.IN);
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> new Client(config));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new Client(config));
   }
 
   @Test

--- a/src/test/java/com/adyen/model/nexo/PredefinedContentHelperTest.java
+++ b/src/test/java/com/adyen/model/nexo/PredefinedContentHelperTest.java
@@ -1,12 +1,12 @@
 package com.adyen.model.nexo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link PredefinedContentHelper}. */
 public class PredefinedContentHelperTest {
@@ -18,7 +18,7 @@ public class PredefinedContentHelperTest {
     PredefinedContentHelper helper = new PredefinedContentHelper(referenceId);
 
     Optional<PredefinedContentHelper.DisplayNotificationEvent> event = helper.getEvent();
-    assertTrue("Event should be present", event.isPresent());
+    assertTrue(event.isPresent(), "Event should be present");
     assertEquals(PredefinedContentHelper.DisplayNotificationEvent.PIN_ENTERED, event.get());
   }
 
@@ -26,7 +26,7 @@ public class PredefinedContentHelperTest {
   public void testShouldReturnEmptyForInvalidEvent() {
     PredefinedContentHelper helper = new PredefinedContentHelper("event=INVALID_EVENT");
 
-    assertFalse("Event should not be present for invalid value", helper.getEvent().isPresent());
+    assertFalse(helper.getEvent().isPresent(), "Event should not be present for invalid value");
   }
 
   @Test
@@ -36,7 +36,7 @@ public class PredefinedContentHelperTest {
             "TransactionID=12345&TimeStamp=2018-02-07T10%3a16%3a14.000Z&event=PIN_ENTERED");
 
     Optional<String> transactionId = helper.getTransactionId();
-    assertTrue("TransactionID should be present", transactionId.isPresent());
+    assertTrue(transactionId.isPresent(), "TransactionID should be present");
     assertEquals("12345", transactionId.get());
   }
 
@@ -45,7 +45,7 @@ public class PredefinedContentHelperTest {
     PredefinedContentHelper helper = new PredefinedContentHelper("TimeStamp=2024-07-11T12:00:00Z");
 
     Optional<String> timeStamp = helper.getTimeStamp();
-    assertTrue("TimeStamp should be present", timeStamp.isPresent());
+    assertTrue(timeStamp.isPresent(), "TimeStamp should be present");
     assertEquals("2024-07-11T12:00:00Z", timeStamp.get());
   }
 
@@ -54,14 +54,14 @@ public class PredefinedContentHelperTest {
     PredefinedContentHelper helper = new PredefinedContentHelper("foo=bar&baz=qux");
 
     Optional<String> foo = helper.get("foo");
-    assertTrue("Value for 'foo' should be present", foo.isPresent());
+    assertTrue(foo.isPresent(), "Value for 'foo' should be present");
     assertEquals("bar", foo.get());
 
     Optional<String> baz = helper.get("baz");
-    assertTrue("Value for 'baz' should be present", baz.isPresent());
+    assertTrue(baz.isPresent(), "Value for 'baz' should be present");
     assertEquals("qux", baz.get());
 
-    assertFalse("Value for 'missing' should not be present", helper.get("missing").isPresent());
+    assertFalse(helper.get("missing").isPresent(), "Value for 'missing' should not be present");
   }
 
   @Test

--- a/src/test/java/com/adyen/serializer/ByteArrayToStringAdapterTest.java
+++ b/src/test/java/com/adyen/serializer/ByteArrayToStringAdapterTest.java
@@ -20,17 +20,17 @@
  */
 package com.adyen.serializer;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import org.apache.commons.codec.binary.Base64;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
 public class ByteArrayToStringAdapterTest {
 
   @Test

--- a/src/test/java/com/adyen/serializer/DateSerializerTest.java
+++ b/src/test/java/com/adyen/serializer/DateSerializerTest.java
@@ -20,14 +20,15 @@
  */
 package com.adyen.serializer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Date;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class DateSerializerTest {
 
   @Test

--- a/src/test/java/com/adyen/serializer/DateTimeGMTSerializerTest.java
+++ b/src/test/java/com/adyen/serializer/DateTimeGMTSerializerTest.java
@@ -20,14 +20,15 @@
  */
 package com.adyen.serializer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Date;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class DateTimeGMTSerializerTest {
 
   @Test

--- a/src/test/java/com/adyen/serializer/DateTimeISO8601SerializerTest.java
+++ b/src/test/java/com/adyen/serializer/DateTimeISO8601SerializerTest.java
@@ -1,19 +1,20 @@
 package com.adyen.serializer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Date;
 import java.util.TimeZone;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class DateTimeISO8601SerializerTest {
   private static final TimeZone defaultTZ = TimeZone.getDefault();
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     TimeZone.setDefault(defaultTZ);
   }

--- a/src/test/java/com/adyen/serializer/ModelTest.java
+++ b/src/test/java/com/adyen/serializer/ModelTest.java
@@ -1,9 +1,9 @@
 package com.adyen.serializer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.adyen.model.checkout.CardDetails;
 import com.adyen.model.checkout.CheckoutPaymentMethod;
@@ -15,7 +15,7 @@ import com.adyen.model.management.TerminalSettings;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.Month;
 import java.time.ZoneId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Test model serialization (toJson) and deserialization (fromJson) */
 public class ModelTest {

--- a/src/test/java/com/adyen/serializer/SaleToAcquirerDataSerializerTest.java
+++ b/src/test/java/com/adyen/serializer/SaleToAcquirerDataSerializerTest.java
@@ -2,7 +2,7 @@ package com.adyen.serializer;
 
 import static com.adyen.Client.LIB_NAME;
 import static com.adyen.Client.LIB_VERSION;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.adyen.model.applicationinfo.ApplicationInfo;
 import com.adyen.model.applicationinfo.ExternalPlatform;
@@ -14,7 +14,7 @@ import com.google.gson.JsonParser;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.codec.binary.Base64;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SaleToAcquirerDataSerializerTest {
 

--- a/src/test/java/com/adyen/serializer/XMLEnumSerializerTest.java
+++ b/src/test/java/com/adyen/serializer/XMLEnumSerializerTest.java
@@ -20,20 +20,21 @@
  */
 package com.adyen.serializer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.adyen.model.nexo.AccountType;
 import com.adyen.model.nexo.AuthenticationMethodType;
 import com.adyen.terminal.serialization.XMLEnumTypeAdapter;
 import com.google.gson.stream.JsonReader;
 import java.io.StringReader;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class XMLEnumSerializerTest {
 
   @Test

--- a/src/test/java/com/adyen/service/ResourceTest.java
+++ b/src/test/java/com/adyen/service/ResourceTest.java
@@ -20,7 +20,7 @@
  */
 package com.adyen.service;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.verify;
@@ -39,13 +39,17 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
+import org.mockito.Mock;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class ResourceTest extends BaseTest {
   @Mock Service serviceMock;
 
@@ -53,7 +57,7 @@ public class ResourceTest extends BaseTest {
 
   @Mock ClientInterface clientInterfaceMock;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(clientMock.getHttpClient()).thenReturn(clientInterfaceMock);
     when(clientMock.getConfig()).thenReturn(null);

--- a/src/test/java/com/adyen/service/balanceplatform/TransferLimitsBalanceAccountLevelApiTest.java
+++ b/src/test/java/com/adyen/service/balanceplatform/TransferLimitsBalanceAccountLevelApiTest.java
@@ -11,8 +11,8 @@
 
 package com.adyen.service.balanceplatform;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 
 import com.adyen.BaseTest;
@@ -21,7 +21,7 @@ import com.adyen.constants.ApiConstants;
 import com.adyen.model.balanceplatform.*;
 import java.time.OffsetDateTime;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransferLimitsBalanceAccountLevelApiTest extends BaseTest {
 

--- a/src/test/java/com/adyen/service/balanceplatform/TransferLimitsBalancePlatformLevelApiTest.java
+++ b/src/test/java/com/adyen/service/balanceplatform/TransferLimitsBalancePlatformLevelApiTest.java
@@ -11,8 +11,8 @@
 
 package com.adyen.service.balanceplatform;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 
 import com.adyen.BaseTest;
@@ -21,7 +21,7 @@ import com.adyen.constants.ApiConstants;
 import com.adyen.model.balanceplatform.*;
 import java.time.OffsetDateTime;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransferLimitsBalancePlatformLevelApiTest extends BaseTest {
 

--- a/src/test/java/com/adyen/terminal/security/TerminalCommonNameValidatorTest.java
+++ b/src/test/java/com/adyen/terminal/security/TerminalCommonNameValidatorTest.java
@@ -21,26 +21,23 @@
 
 package com.adyen.terminal.security;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.adyen.enums.Environment;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.security.auth.x500.X500Principal;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(Parameterized.class)
+@ExtendWith(MockitoExtension.class)
 public class TerminalCommonNameValidatorTest {
 
-  @Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
@@ -186,27 +183,12 @@ public class TerminalCommonNameValidatorTest {
         });
   }
 
-  private final String certificateName;
-  private final Environment environment;
-  private final boolean expectedResult;
-
   @Mock private X509Certificate certificate;
   @Mock private X500Principal principal;
 
-  public TerminalCommonNameValidatorTest(
-      String certificateName, Environment environment, boolean expectedResult) {
-    this.certificateName = certificateName;
-    this.environment = environment;
-    this.expectedResult = expectedResult;
-  }
-
-  @Before
-  public void setUp() {
-    initMocks(this);
-  }
-
-  @Test
-  public void testSerialize() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSerialize(String certificateName, Environment environment, boolean expectedResult) {
     when(certificate.getSubjectX500Principal()).thenReturn(principal);
     when(principal.getName()).thenReturn(certificateName);
 

--- a/src/test/java/com/adyen/util/CertificateUtilTest.java
+++ b/src/test/java/com/adyen/util/CertificateUtilTest.java
@@ -29,14 +29,14 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CertificateUtilTest {
 
   @Test
   public void testErrorLoadingCertificateFromPath() {
-    Assert.assertThrows(FileNotFoundException.class, () -> CertificateUtil.loadCertificate(""));
+    Assertions.assertThrows(FileNotFoundException.class, () -> CertificateUtil.loadCertificate(""));
   }
 
   @Test
@@ -44,7 +44,7 @@ public class CertificateUtilTest {
     String path = getClass().getClassLoader().getResource("adyen-terminalfleet-test.pem").getPath();
     Certificate certificate = CertificateUtil.loadCertificate(path);
 
-    Assert.assertNotNull(certificate);
+    Assertions.assertNotNull(certificate);
   }
 
   @Test
@@ -53,7 +53,7 @@ public class CertificateUtilTest {
         getClass().getClassLoader().getResourceAsStream("adyen-terminalfleet-test.pem");
     Certificate certificate = CertificateUtil.loadCertificate(stream);
 
-    Assert.assertNotNull(certificate);
+    Assertions.assertNotNull(certificate);
   }
 
   @Test
@@ -64,8 +64,8 @@ public class CertificateUtilTest {
     KeyStore keyStore =
         CertificateUtil.loadKeyStore(resource.getPath(), KeyStore.getDefaultType(), "test1234");
 
-    Assert.assertNotNull(keyStore);
-    Assert.assertTrue(keyStore.containsAlias("boguscert"));
+    Assertions.assertNotNull(keyStore);
+    Assertions.assertTrue(keyStore.containsAlias("boguscert"));
   }
 
   @Test
@@ -76,26 +76,26 @@ public class CertificateUtilTest {
     KeyStore keyStore =
         CertificateUtil.loadKeyStore(resource.getPath(), KeyStore.getDefaultType(), null);
 
-    Assert.assertNotNull(keyStore);
-    Assert.assertTrue(keyStore.containsAlias("boguscert"));
+    Assertions.assertNotNull(keyStore);
+    Assertions.assertTrue(keyStore.containsAlias("boguscert"));
   }
 
   @Test
   public void testLoadKeyStore_FileNotFoundErrorOnInvalidPath() {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         FileNotFoundException.class,
         () -> CertificateUtil.loadKeyStore("xyz", KeyStore.getDefaultType(), ""));
   }
 
   @Test
   public void testLoadKeyStore_ErrorOnNullKeyStorePath() {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class, () -> CertificateUtil.loadKeyStore(null, "JKS", ""));
   }
 
   @Test
   public void testLoadKeyStore_ErrorOnNullKeyStoreType() {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class, () -> CertificateUtil.loadKeyStore("xyz", null, ""));
   }
 }

--- a/src/test/java/com/adyen/util/HMACValidatorTest.java
+++ b/src/test/java/com/adyen/util/HMACValidatorTest.java
@@ -21,15 +21,15 @@
 
 package com.adyen.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.adyen.BaseTest;
 import com.adyen.model.notification.NotificationRequestItem;
 import com.google.gson.Gson;
 import java.security.SignatureException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HMACValidatorTest extends BaseTest {
 

--- a/src/test/java/com/adyen/util/MaskUtilTest.java
+++ b/src/test/java/com/adyen/util/MaskUtilTest.java
@@ -20,9 +20,9 @@
  */
 package com.adyen.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MaskUtilTest {
 

--- a/src/test/java/com/adyen/webhooks/BalancePlatformWebhooksTest.java
+++ b/src/test/java/com/adyen/webhooks/BalancePlatformWebhooksTest.java
@@ -1,6 +1,6 @@
 package com.adyen.webhooks;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.adyen.BaseTest;
 import com.adyen.model.acswebhooks.AcsWebhooksHandler;
@@ -24,8 +24,8 @@ import com.adyen.model.transferwebhooks.TransferWebhooksHandler;
 import com.adyen.util.HMACValidator;
 import java.security.SignatureException;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Unit testing for all AfP/Bank related webhooks */
 public class BalancePlatformWebhooksTest extends BaseTest {
@@ -181,11 +181,11 @@ public class BalancePlatformWebhooksTest extends BaseTest {
         "{ \"data\": {\"balancePlatform\": \"YOUR_BALANCE_PLATFORM\",\"accountHolder\": {\"contactDetails\": {\"address\": {\"country\": \"NL\",\"houseNumberOrName\": \"274\",\"postalCode\": \"1020CD\",\"street\": \"Brannan Street\"},\"email\": \"s.hopper@example.com\",\"phone\": {\"number\": \"+315551231234\",\"type\": \"mobile\"}},\"description\": \"S.Hopper - Staff 123\",\"id\": \"AH00000000000000000000001\",\"status\": \"active\"}},\"environment\": \"test\",\"type\": \"balancePlatform.accountHolder.created\"}";
     ConfigurationWebhooksHandler webhookHandler = new ConfigurationWebhooksHandler(jsonRequest);
 
-    Assert.assertTrue(webhookHandler.getAccountHolderNotificationRequest().isPresent());
+    Assertions.assertTrue(webhookHandler.getAccountHolderNotificationRequest().isPresent());
 
     AccountHolderNotificationRequest accountHolderNotificationRequest =
         webhookHandler.getAccountHolderNotificationRequest().get();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "AH00000000000000000000001",
         accountHolderNotificationRequest.getData().getAccountHolder().getId());
   }
@@ -196,18 +196,18 @@ public class BalancePlatformWebhooksTest extends BaseTest {
         getFileContents(
             "mocks/balancePlatform-webhooks/configuration-accountHolder-created-castexception.json");
     ConfigurationWebhooksHandler webhookHandler = new ConfigurationWebhooksHandler(json);
-    Assert.assertTrue(webhookHandler.getAccountHolderNotificationRequest().isPresent());
+    Assertions.assertTrue(webhookHandler.getAccountHolderNotificationRequest().isPresent());
     // verify other event is not present
-    Assert.assertFalse(webhookHandler.getCardOrderNotificationRequest().isPresent());
+    Assertions.assertFalse(webhookHandler.getCardOrderNotificationRequest().isPresent());
     // verify other event is not present
-    Assert.assertFalse(webhookHandler.getBalanceAccountNotificationRequest().isPresent());
+    Assertions.assertFalse(webhookHandler.getBalanceAccountNotificationRequest().isPresent());
   }
 
   @Test
   public void testBankingWebhookInvalidPayload() {
     String jsonRequest = "{ invalid json ...";
     ConfigurationWebhooksHandler webhookHandler = new ConfigurationWebhooksHandler(jsonRequest);
-    Assert.assertTrue(webhookHandler.getAccountHolderNotificationRequest().isEmpty());
+    Assertions.assertTrue(webhookHandler.getAccountHolderNotificationRequest().isEmpty());
   }
 
   @Test
@@ -218,7 +218,7 @@ public class BalancePlatformWebhooksTest extends BaseTest {
     String hmacKey = "9Qz9S/0xpar1klkniKdshxpAhRKbiSAewPpWoxKefQA=";
     HMACValidator hmacValidator = new HMACValidator();
     boolean response = hmacValidator.validateHMAC(hmacKey, signKey, notification);
-    Assert.assertTrue(response);
+    Assertions.assertTrue(response);
   }
 
   @Test
@@ -249,10 +249,10 @@ public class BalancePlatformWebhooksTest extends BaseTest {
   public void testTransactionWebhookParsing() {
     String json = getFileContents("mocks/notification/balancePlatform-transaction-created.json");
     TransactionWebhooksHandler webhookHandler = new TransactionWebhooksHandler(json);
-    Assert.assertTrue(webhookHandler.getTransactionNotificationRequestV4().isPresent());
+    Assertions.assertTrue(webhookHandler.getTransactionNotificationRequestV4().isPresent());
     TransactionNotificationRequestV4 request =
         webhookHandler.getTransactionNotificationRequestV4().get();
-    Assert.assertEquals("EVJN42272224222B5JB8BRC84N686ZEUR", request.getData().getId());
+    Assertions.assertEquals("EVJN42272224222B5JB8BRC84N686ZEUR", request.getData().getId());
   }
 
   @Test
@@ -475,7 +475,7 @@ public class BalancePlatformWebhooksTest extends BaseTest {
     ConfigurationWebhooksHandler handler = new ConfigurationWebhooksHandler(json);
     Optional<ScoreNotificationRequest> optionalRequest = handler.getScoreNotificationRequest();
 
-    assertTrue("The ScoreNotificationRequest should be present", optionalRequest.isPresent());
+    assertTrue(optionalRequest.isPresent(), "The ScoreNotificationRequest should be present");
 
     ScoreNotificationRequest request = optionalRequest.get();
     assertEquals(

--- a/src/test/java/com/adyen/webhooks/ManagementWebhookTest.java
+++ b/src/test/java/com/adyen/webhooks/ManagementWebhookTest.java
@@ -23,8 +23,8 @@ package com.adyen.webhooks;
 import com.adyen.BaseTest;
 import com.adyen.model.managementwebhooks.*;
 import java.io.IOException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Unit testing for Management webhooks */
 public class ManagementWebhookTest extends BaseTest {
@@ -34,13 +34,13 @@ public class ManagementWebhookTest extends BaseTest {
     String json =
         getFileContents("mocks/notification/management-webhook-payment-method-created.json");
     ManagementWebhooksHandler webhookHandler = new ManagementWebhooksHandler(json);
-    Assert.assertTrue(webhookHandler.getPaymentMethodCreatedNotificationRequest().isPresent());
+    Assertions.assertTrue(webhookHandler.getPaymentMethodCreatedNotificationRequest().isPresent());
     PaymentMethodCreatedNotificationRequest request =
         webhookHandler.getPaymentMethodCreatedNotificationRequest().get();
-    Assert.assertEquals("PM1234567890000000", request.getData().getId());
-    Assert.assertEquals(
+    Assertions.assertEquals("PM1234567890000000", request.getData().getId());
+    Assertions.assertEquals(
         PaymentMethodCreatedNotificationRequest.TypeEnum.PAYMENTMETHOD_CREATED, request.getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         MidServiceNotificationData.StatusEnum.SUCCESS, request.getData().getStatus());
   }
 
@@ -50,13 +50,13 @@ public class ManagementWebhookTest extends BaseTest {
         getFileContents(
             "mocks/notification/management-webhook-payment-method-created-unknown-enum.json");
     ManagementWebhooksHandler webhookHandler = new ManagementWebhooksHandler(json);
-    Assert.assertTrue(webhookHandler.getPaymentMethodCreatedNotificationRequest().isPresent());
+    Assertions.assertTrue(webhookHandler.getPaymentMethodCreatedNotificationRequest().isPresent());
     PaymentMethodCreatedNotificationRequest request =
         webhookHandler.getPaymentMethodCreatedNotificationRequest().get();
-    Assert.assertEquals("PM1234567890000000", request.getData().getId());
-    Assert.assertEquals(
+    Assertions.assertEquals("PM1234567890000000", request.getData().getId());
+    Assertions.assertEquals(
         PaymentMethodCreatedNotificationRequest.TypeEnum.PAYMENTMETHOD_CREATED, request.getType());
-    Assert.assertNull(request.getData().getStatus());
+    Assertions.assertNull(request.getData().getStatus());
   }
 
   @Test
@@ -81,11 +81,11 @@ public class ManagementWebhookTest extends BaseTest {
             + "   }\n"
             + "}";
     ManagementWebhooksHandler webhookHandler = new ManagementWebhooksHandler(notification);
-    Assert.assertTrue(webhookHandler.getMerchantUpdatedNotificationRequest().isPresent());
+    Assertions.assertTrue(webhookHandler.getMerchantUpdatedNotificationRequest().isPresent());
     MerchantUpdatedNotificationRequest request =
         webhookHandler.getMerchantUpdatedNotificationRequest().get();
-    Assert.assertEquals("LE322KH223222F5GNNW694PZN", request.getData().getLegalEntityId());
-    Assert.assertEquals(
+    Assertions.assertEquals("LE322KH223222F5GNNW694PZN", request.getData().getLegalEntityId());
+    Assertions.assertEquals(
         MerchantUpdatedNotificationRequest.TypeEnum.MERCHANT_UPDATED, request.getType());
   }
 
@@ -109,11 +109,11 @@ public class ManagementWebhookTest extends BaseTest {
             + "   }\n"
             + "}";
     ManagementWebhooksHandler webhookHandler = new ManagementWebhooksHandler(notification);
-    Assert.assertTrue(webhookHandler.getMerchantCreatedNotificationRequest().isPresent());
+    Assertions.assertTrue(webhookHandler.getMerchantCreatedNotificationRequest().isPresent());
     MerchantCreatedNotificationRequest request =
         webhookHandler.getMerchantCreatedNotificationRequest().get();
-    Assert.assertEquals("MC3224X22322535GH8D537TJR", request.getData().getMerchantId());
-    Assert.assertEquals(
+    Assertions.assertEquals("MC3224X22322535GH8D537TJR", request.getData().getMerchantId());
+    Assertions.assertEquals(
         MerchantCreatedNotificationRequest.TypeEnum.MERCHANT_CREATED, request.getType());
   }
 }

--- a/src/test/java/com/adyen/webhooks/TokenizationWebhookTest.java
+++ b/src/test/java/com/adyen/webhooks/TokenizationWebhookTest.java
@@ -20,13 +20,13 @@
  */
 package com.adyen.webhooks;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.adyen.BaseTest;
 import com.adyen.model.tokenizationwebhooks.*;
 import java.io.IOException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Unit testing for Tokenization webhooks */
 public class TokenizationWebhookTest extends BaseTest {
@@ -37,7 +37,7 @@ public class TokenizationWebhookTest extends BaseTest {
         getFileContents(
             "mocks/notification/tokenization-webhook-recurring-token-alreadyExisting.json");
     TokenizationWebhooksHandler webhookHandler = new TokenizationWebhooksHandler(json);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         webhookHandler.getTokenizationAlreadyExistingDetailsNotificationRequest().isPresent());
 
     var request = webhookHandler.getTokenizationAlreadyExistingDetailsNotificationRequest().get();
@@ -49,8 +49,8 @@ public class TokenizationWebhookTest extends BaseTest {
         TokenizationAlreadyExistingDetailsNotificationRequest.EnvironmentEnum.TEST,
         request.getEnvironment());
 
-    Assert.assertEquals("YOUR_MERCHANT_ACCOUNT", request.getData().getMerchantAccount());
-    Assert.assertEquals("M5N7TQ4TG5PFWR50", request.getData().getStoredPaymentMethodId());
+    Assertions.assertEquals("YOUR_MERCHANT_ACCOUNT", request.getData().getMerchantAccount());
+    Assertions.assertEquals("M5N7TQ4TG5PFWR50", request.getData().getStoredPaymentMethodId());
   }
 
   @Test
@@ -58,7 +58,7 @@ public class TokenizationWebhookTest extends BaseTest {
     String json =
         getFileContents("mocks/notification/tokenization-webhook-recurring-token-created.json");
     TokenizationWebhooksHandler webhookHandler = new TokenizationWebhooksHandler(json);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         webhookHandler.getTokenizationCreatedDetailsNotificationRequest().isPresent());
 
     var request = webhookHandler.getTokenizationCreatedDetailsNotificationRequest().get();
@@ -69,8 +69,8 @@ public class TokenizationWebhookTest extends BaseTest {
         TokenizationCreatedDetailsNotificationRequest.EnvironmentEnum.TEST,
         request.getEnvironment());
 
-    Assert.assertEquals("YOUR_MERCHANT_ACCOUNT", request.getData().getMerchantAccount());
-    Assert.assertEquals("M5N7TQ4TG5PFWR50", request.getData().getStoredPaymentMethodId());
+    Assertions.assertEquals("YOUR_MERCHANT_ACCOUNT", request.getData().getMerchantAccount());
+    Assertions.assertEquals("M5N7TQ4TG5PFWR50", request.getData().getStoredPaymentMethodId());
   }
 
   @Test
@@ -78,7 +78,7 @@ public class TokenizationWebhookTest extends BaseTest {
     String json =
         getFileContents("mocks/notification/tokenization-webhook-recurring-token-disabled.json");
     TokenizationWebhooksHandler webhookHandler = new TokenizationWebhooksHandler(json);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         webhookHandler.getTokenizationDisabledDetailsNotificationRequest().isPresent());
 
     var request = webhookHandler.getTokenizationDisabledDetailsNotificationRequest().get();
@@ -89,8 +89,8 @@ public class TokenizationWebhookTest extends BaseTest {
         TokenizationDisabledDetailsNotificationRequest.EnvironmentEnum.TEST,
         request.getEnvironment());
 
-    Assert.assertEquals("YOUR_MERCHANT_ACCOUNT", request.getData().getMerchantAccount());
-    Assert.assertEquals("M5N7TQ4TG5PFWR50", request.getData().getStoredPaymentMethodId());
+    Assertions.assertEquals("YOUR_MERCHANT_ACCOUNT", request.getData().getMerchantAccount());
+    Assertions.assertEquals("M5N7TQ4TG5PFWR50", request.getData().getStoredPaymentMethodId());
   }
 
   @Test
@@ -98,7 +98,7 @@ public class TokenizationWebhookTest extends BaseTest {
     String json =
         getFileContents("mocks/notification/tokenization-webhook-recurring-token-updated.json");
     TokenizationWebhooksHandler webhookHandler = new TokenizationWebhooksHandler(json);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         webhookHandler.getTokenizationUpdatedDetailsNotificationRequest().isPresent());
 
     var request = webhookHandler.getTokenizationUpdatedDetailsNotificationRequest().get();
@@ -109,7 +109,7 @@ public class TokenizationWebhookTest extends BaseTest {
         TokenizationUpdatedDetailsNotificationRequest.EnvironmentEnum.TEST,
         request.getEnvironment());
 
-    Assert.assertEquals("YOUR_MERCHANT_ACCOUNT", request.getData().getMerchantAccount());
-    Assert.assertEquals("M5N7TQ4TG5PFWR50", request.getData().getStoredPaymentMethodId());
+    Assertions.assertEquals("YOUR_MERCHANT_ACCOUNT", request.getData().getMerchantAccount());
+    Assertions.assertEquals("M5N7TQ4TG5PFWR50", request.getData().getStoredPaymentMethodId());
   }
 }

--- a/src/test/java/com/adyen/webhooks/WebhookTest.java
+++ b/src/test/java/com/adyen/webhooks/WebhookTest.java
@@ -20,7 +20,7 @@
  */
 package com.adyen.webhooks;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.adyen.BaseTest;
 import com.adyen.model.marketpaywebhooks.AccountHolderCreateNotification;
@@ -36,16 +36,16 @@ import com.adyen.notification.ClassicPlatformWebhookHandler;
 import com.adyen.notification.WebhookHandler;
 import java.io.IOException;
 import java.util.ArrayList;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Tests notification messages */
 public class WebhookTest extends BaseTest {
 
   private WebhookHandler webhookHandler;
 
-  @Before
+  @BeforeEach
   public void init() {
     webhookHandler = new WebhookHandler();
   }
@@ -327,7 +327,7 @@ public class WebhookTest extends BaseTest {
     WebhookHandler webhookHolder = new WebhookHandler();
     NotificationRequest notificationRequest =
         webhookHolder.handleNotificationJsonJackson(notification);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "EUR",
         notificationRequest
             .getNotificationItemContainers()
@@ -335,7 +335,7 @@ public class WebhookTest extends BaseTest {
             .getNotificationItem()
             .getAmount()
             .getCurrency());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "TestMerchantAccount",
         notificationRequest
             .getNotificationItemContainers()
@@ -570,9 +570,9 @@ public class WebhookTest extends BaseTest {
             + "  }\n"
             + "}";
     ClassicPlatformWebhookHandler webhookHandler = new ClassicPlatformWebhookHandler(notification);
-    Assert.assertTrue(webhookHandler.getAccountHolderCreateNotification().isPresent());
+    Assertions.assertTrue(webhookHandler.getAccountHolderCreateNotification().isPresent());
     AccountHolderCreateNotification payload =
         webhookHandler.getAccountHolderCreateNotification().get();
-    Assert.assertEquals("ACCOUNT_HOLDER_CREATED", payload.getEventType());
+    Assertions.assertEquals("ACCOUNT_HOLDER_CREATED", payload.getEventType());
   }
 }


### PR DESCRIPTION
**Description**
This PR upgrades the Junit dependency from 4 to 5, ensuring we use a more modernized approach to unit testing. In conjunction, we added Hamcrest matching. 

**Tested scenarios**
All tests run successfully locally