### PR TITLE
Update cache action version in action.yml

### DIFF
--- a/.github/actions/format/action.yml
+++ b/.github/actions/format/action.yml
@@ -14,7 +14,7 @@ runs:
         distribution: 'temurin'
 
     - name: Cache Maven packages
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@b7e8d49f17405cc70c1c120101943203c98d3a4b
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles(format('{0}/**/pom.xml', inputs.path)) }}


### PR DESCRIPTION
PR #1627 has updated incorrectly the version of `actions-setup` in the format `action.yml`. Other workflows were updated correctly.

This PR corrects the  `actions/cache` version in `action.yml`.
