### PR TITLE
Add test coverage for serialization/deserialization for upcoming refactoring

### DIFF
--- a/src/test/java/com/adyen/model/nexo/AbortRequestTest.java
+++ b/src/test/java/com/adyen/model/nexo/AbortRequestTest.java
@@ -1,0 +1,69 @@
+package com.adyen.model.nexo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.adyen.terminal.serialization.TerminalAPIGsonBuilder;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class AbortRequestTest {
+
+  @Test
+  public void testShouldSerializeAndDeserializeFromMockFile() throws IOException {
+    String mockJson = NexoTestUtils.readResource("mocks/terminal-api/abort-request.json");
+    Gson terminalApiGson = TerminalAPIGsonBuilder.create();
+
+    AbortRequest deserializedAbortRequest = terminalApiGson.fromJson(mockJson, AbortRequest.class);
+    assertEquals("cancelled-by-shopper", deserializedAbortRequest.getAbortReason());
+    assertEquals(
+        MessageCategoryType.PAYMENT,
+        deserializedAbortRequest.getMessageReference().getMessageCategory());
+    assertEquals("service-id", deserializedAbortRequest.getMessageReference().getServiceID());
+    assertEquals("device-id", deserializedAbortRequest.getMessageReference().getDeviceID());
+    assertEquals("sale-id", deserializedAbortRequest.getMessageReference().getSaleID());
+    assertEquals("poi-id", deserializedAbortRequest.getMessageReference().getPOIID());
+    assertEquals(
+        "Abort requested",
+        deserializedAbortRequest
+            .getDisplayOutput()
+            .getOutputContent()
+            .getOutputText()
+            .get(0)
+            .getText());
+    assertEquals(
+        DeviceType.CUSTOMER_DISPLAY, deserializedAbortRequest.getDisplayOutput().getDevice());
+    assertEquals(
+        InfoQualifyType.ERROR, deserializedAbortRequest.getDisplayOutput().getInfoQualify());
+    assertEquals(
+        OutputFormatType.TEXT,
+        deserializedAbortRequest.getDisplayOutput().getOutputContent().getOutputFormat());
+
+    String serializedJson = terminalApiGson.toJson(deserializedAbortRequest);
+
+    JsonObject expectedJsonObject = JsonParser.parseString(mockJson).getAsJsonObject();
+    JsonObject serializedJsonObject = JsonParser.parseString(serializedJson).getAsJsonObject();
+    assertEquals(expectedJsonObject, serializedJsonObject);
+
+    AbortRequest roundTripAbortRequest =
+        terminalApiGson.fromJson(serializedJson, AbortRequest.class);
+    assertEquals(deserializedAbortRequest.getAbortReason(), roundTripAbortRequest.getAbortReason());
+    assertEquals(
+        deserializedAbortRequest.getMessageReference().getServiceID(),
+        roundTripAbortRequest.getMessageReference().getServiceID());
+    assertEquals(
+        deserializedAbortRequest.getMessageReference().getDeviceID(),
+        roundTripAbortRequest.getMessageReference().getDeviceID());
+    assertEquals(
+        deserializedAbortRequest.getMessageReference().getSaleID(),
+        roundTripAbortRequest.getMessageReference().getSaleID());
+    assertEquals(
+        deserializedAbortRequest.getMessageReference().getPOIID(),
+        roundTripAbortRequest.getMessageReference().getPOIID());
+    assertEquals(
+        deserializedAbortRequest.getDisplayOutput().getInfoQualify(),
+        roundTripAbortRequest.getDisplayOutput().getInfoQualify());
+  }
+}

--- a/src/test/java/com/adyen/model/nexo/DisplayRequestTest.java
+++ b/src/test/java/com/adyen/model/nexo/DisplayRequestTest.java
@@ -1,0 +1,59 @@
+package com.adyen.model.nexo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.adyen.terminal.serialization.TerminalAPIGsonBuilder;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class DisplayRequestTest {
+
+  @Test
+  public void testShouldSerializeAndDeserializeFromMockFile() throws IOException {
+    String mockJson = NexoTestUtils.readResource("mocks/terminal-api/display-request.json");
+    Gson terminalApiGson = TerminalAPIGsonBuilder.create();
+
+    DisplayRequest deserializedDisplayRequest =
+        terminalApiGson.fromJson(mockJson, DisplayRequest.class);
+    assertEquals(1, deserializedDisplayRequest.getDisplayOutput().size());
+    assertEquals(
+        DeviceType.CUSTOMER_DISPLAY,
+        deserializedDisplayRequest.getDisplayOutput().get(0).getDevice());
+    assertEquals(
+        InfoQualifyType.DISPLAY,
+        deserializedDisplayRequest.getDisplayOutput().get(0).getInfoQualify());
+    assertEquals(
+        OutputFormatType.TEXT,
+        deserializedDisplayRequest.getDisplayOutput().get(0).getOutputContent().getOutputFormat());
+    assertEquals(
+        "Please present card",
+        deserializedDisplayRequest
+            .getDisplayOutput()
+            .get(0)
+            .getOutputContent()
+            .getOutputText()
+            .get(0)
+            .getText());
+
+    String serializedJson = terminalApiGson.toJson(deserializedDisplayRequest);
+
+    JsonObject expectedJsonObject = JsonParser.parseString(mockJson).getAsJsonObject();
+    JsonObject serializedJsonObject = JsonParser.parseString(serializedJson).getAsJsonObject();
+    assertEquals(expectedJsonObject, serializedJsonObject);
+
+    DisplayRequest roundTripDisplayRequest =
+        terminalApiGson.fromJson(serializedJson, DisplayRequest.class);
+    assertEquals(
+        "Please present card",
+        roundTripDisplayRequest
+            .getDisplayOutput()
+            .get(0)
+            .getOutputContent()
+            .getOutputText()
+            .get(0)
+            .getText());
+  }
+}

--- a/src/test/java/com/adyen/model/nexo/LoginRequestTest.java
+++ b/src/test/java/com/adyen/model/nexo/LoginRequestTest.java
@@ -1,0 +1,68 @@
+package com.adyen.model.nexo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.adyen.terminal.serialization.TerminalAPIGsonBuilder;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class LoginRequestTest {
+
+  @Test
+  public void testShouldSerializeAndDeserializeFromMockFile() throws IOException {
+    String mockJson = NexoTestUtils.readResource("mocks/terminal-api/login-request.json");
+    Gson terminalApiGson = TerminalAPIGsonBuilder.create();
+
+    LoginRequest deserializedLoginRequest = terminalApiGson.fromJson(mockJson, LoginRequest.class);
+    assertEquals("2026-03-26T10:15:30Z", deserializedLoginRequest.getDateTime().toString());
+    assertEquals("adyen", deserializedLoginRequest.getSaleSoftware().getManufacturerID());
+    assertEquals("register-app", deserializedLoginRequest.getSaleSoftware().getApplicationName());
+    assertEquals("1.0.0", deserializedLoginRequest.getSaleSoftware().getSoftwareVersion());
+    assertEquals("cert-123", deserializedLoginRequest.getSaleSoftware().getCertificationCode());
+    assertEquals(2, deserializedLoginRequest.getSaleTerminalData().getSaleCapabilities().size());
+    assertEquals(
+        SaleCapabilitiesType.CASHIER_DISPLAY,
+        deserializedLoginRequest.getSaleTerminalData().getSaleCapabilities().get(0));
+    assertEquals(
+        SaleCapabilitiesType.CUSTOMER_DISPLAY,
+        deserializedLoginRequest.getSaleTerminalData().getSaleCapabilities().get(1));
+    assertEquals(
+        TerminalEnvironmentType.ATTENDED,
+        deserializedLoginRequest.getSaleTerminalData().getTerminalEnvironment());
+    assertEquals("group-1", deserializedLoginRequest.getSaleTerminalData().getTotalsGroupID());
+    assertTrue(deserializedLoginRequest.isTrainingModeFlag());
+    assertEquals("en", deserializedLoginRequest.getOperatorLanguage());
+    assertEquals("operator-1", deserializedLoginRequest.getOperatorID());
+    assertEquals("shift-1", deserializedLoginRequest.getShiftNumber());
+    assertEquals(TokenRequestedType.TRANSACTION, deserializedLoginRequest.getTokenRequestedType());
+    assertEquals(2, deserializedLoginRequest.getCustomerOrderReq().size());
+    assertEquals(CustomerOrderReqType.OPEN, deserializedLoginRequest.getCustomerOrderReq().get(0));
+    assertEquals(
+        CustomerOrderReqType.CLOSED, deserializedLoginRequest.getCustomerOrderReq().get(1));
+    assertEquals("poi-serial-1", deserializedLoginRequest.getPOISerialNumber());
+
+    String serializedJson = terminalApiGson.toJson(deserializedLoginRequest);
+
+    JsonObject expectedJsonObject = JsonParser.parseString(mockJson).getAsJsonObject();
+    JsonObject serializedJsonObject = JsonParser.parseString(serializedJson).getAsJsonObject();
+    assertEquals(expectedJsonObject, serializedJsonObject);
+
+    LoginRequest roundTripLoginRequest =
+        terminalApiGson.fromJson(serializedJson, LoginRequest.class);
+    assertEquals(
+        deserializedLoginRequest.getDateTime().toString(),
+        roundTripLoginRequest.getDateTime().toString());
+    assertEquals(
+        deserializedLoginRequest.getTokenRequestedType(),
+        roundTripLoginRequest.getTokenRequestedType());
+    assertEquals(
+        deserializedLoginRequest.getCustomerOrderReq(),
+        roundTripLoginRequest.getCustomerOrderReq());
+    assertEquals(
+        deserializedLoginRequest.getPOISerialNumber(), roundTripLoginRequest.getPOISerialNumber());
+  }
+}

--- a/src/test/java/com/adyen/model/nexo/MessageHeaderTest.java
+++ b/src/test/java/com/adyen/model/nexo/MessageHeaderTest.java
@@ -1,0 +1,49 @@
+package com.adyen.model.nexo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.adyen.terminal.serialization.TerminalAPIGsonBuilder;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+public class MessageHeaderTest {
+
+  @Test
+  public void testShouldSerializeAndDeserializeFromMockFile() throws IOException {
+    String mockJson = NexoTestUtils.readResource("mocks/terminal-api/message-header.json");
+    Gson terminalApiGson = TerminalAPIGsonBuilder.create();
+
+    MessageHeader deserializedMessageHeader =
+        terminalApiGson.fromJson(mockJson, MessageHeader.class);
+    String serializedJson = terminalApiGson.toJson(deserializedMessageHeader);
+
+    JsonObject expectedJsonObject = JsonParser.parseString(mockJson).getAsJsonObject();
+    JsonObject serializedJsonObject = JsonParser.parseString(serializedJson).getAsJsonObject();
+    assertEquals(expectedJsonObject, serializedJsonObject);
+
+    MessageHeader roundTripMessageHeader =
+        terminalApiGson.fromJson(serializedJson, MessageHeader.class);
+    assertEquals(
+        deserializedMessageHeader.getProtocolVersion(),
+        roundTripMessageHeader.getProtocolVersion());
+    assertEquals(
+        deserializedMessageHeader.getMessageClass(), roundTripMessageHeader.getMessageClass());
+    assertEquals(
+        deserializedMessageHeader.getMessageCategory(),
+        roundTripMessageHeader.getMessageCategory());
+    assertEquals(
+        deserializedMessageHeader.getMessageType(), roundTripMessageHeader.getMessageType());
+    assertEquals(deserializedMessageHeader.getServiceID(), roundTripMessageHeader.getServiceID());
+    assertEquals(deserializedMessageHeader.getDeviceID(), roundTripMessageHeader.getDeviceID());
+    assertEquals(deserializedMessageHeader.getSaleID(), roundTripMessageHeader.getSaleID());
+    assertEquals(deserializedMessageHeader.getPOIID(), roundTripMessageHeader.getPOIID());
+  }
+}

--- a/src/test/java/com/adyen/model/nexo/MessageReferenceTest.java
+++ b/src/test/java/com/adyen/model/nexo/MessageReferenceTest.java
@@ -1,0 +1,45 @@
+package com.adyen.model.nexo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.adyen.terminal.serialization.TerminalAPIGsonBuilder;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class MessageReferenceTest {
+
+  @Test
+  public void testShouldSerializeAndDeserializeFromMockFile() throws IOException {
+    String mockJson = NexoTestUtils.readResource("mocks/terminal-api/message-reference.json");
+    Gson terminalApiGson = TerminalAPIGsonBuilder.create();
+
+    MessageReference deserializedMessageReference =
+        terminalApiGson.fromJson(mockJson, MessageReference.class);
+    assertEquals(MessageCategoryType.PAYMENT, deserializedMessageReference.getMessageCategory());
+    assertEquals("service-id", deserializedMessageReference.getServiceID());
+    assertEquals("device-id", deserializedMessageReference.getDeviceID());
+    assertEquals("sale-id", deserializedMessageReference.getSaleID());
+    assertEquals("poi-id", deserializedMessageReference.getPOIID());
+
+    String serializedJson = terminalApiGson.toJson(deserializedMessageReference);
+
+    JsonObject expectedJsonObject = JsonParser.parseString(mockJson).getAsJsonObject();
+    JsonObject serializedJsonObject = JsonParser.parseString(serializedJson).getAsJsonObject();
+    assertEquals(expectedJsonObject, serializedJsonObject);
+
+    MessageReference roundTripMessageReference =
+        terminalApiGson.fromJson(serializedJson, MessageReference.class);
+    assertEquals(
+        deserializedMessageReference.getMessageCategory(),
+        roundTripMessageReference.getMessageCategory());
+    assertEquals(
+        deserializedMessageReference.getServiceID(), roundTripMessageReference.getServiceID());
+    assertEquals(
+        deserializedMessageReference.getDeviceID(), roundTripMessageReference.getDeviceID());
+    assertEquals(deserializedMessageReference.getSaleID(), roundTripMessageReference.getSaleID());
+    assertEquals(deserializedMessageReference.getPOIID(), roundTripMessageReference.getPOIID());
+  }
+}

--- a/src/test/java/com/adyen/model/nexo/NexoTestUtils.java
+++ b/src/test/java/com/adyen/model/nexo/NexoTestUtils.java
@@ -1,0 +1,20 @@
+package com.adyen.model.nexo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+final class NexoTestUtils {
+
+  private NexoTestUtils() {}
+
+  static String readResource(String fileName) throws IOException {
+    ClassLoader classLoader = NexoTestUtils.class.getClassLoader();
+    try (InputStream fileStream = classLoader.getResourceAsStream(fileName)) {
+      if (fileStream == null) {
+        throw new IOException("Unable to load resource: " + fileName);
+      }
+      return new String(fileStream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/src/test/resources/mocks/terminal-api/abort-request.json
+++ b/src/test/resources/mocks/terminal-api/abort-request.json
@@ -1,0 +1,24 @@
+{
+  "MessageReference": {
+    "MessageCategory": "Payment",
+    "ServiceID": "service-id",
+    "DeviceID": "device-id",
+    "SaleID": "sale-id",
+    "POIID": "poi-id"
+  },
+  "AbortReason": "cancelled-by-shopper",
+  "DisplayOutput": {
+    "OutputContent": {
+      "OutputText": [
+        {
+          "Text": "Abort requested"
+        }
+      ],
+      "OutputFormat": "Text"
+    },
+    "ResponseRequiredFlag": false,
+    "MinimumDisplayTime": 3,
+    "Device": "CustomerDisplay",
+    "InfoQualify": "Error"
+  }
+}

--- a/src/test/resources/mocks/terminal-api/display-request.json
+++ b/src/test/resources/mocks/terminal-api/display-request.json
@@ -1,0 +1,18 @@
+{
+  "DisplayOutput": [
+    {
+      "OutputContent": {
+        "OutputText": [
+          {
+            "Text": "Please present card"
+          }
+        ],
+        "OutputFormat": "Text"
+      },
+      "ResponseRequiredFlag": true,
+      "MinimumDisplayTime": 5,
+      "Device": "CustomerDisplay",
+      "InfoQualify": "Display"
+    }
+  ]
+}

--- a/src/test/resources/mocks/terminal-api/login-request.json
+++ b/src/test/resources/mocks/terminal-api/login-request.json
@@ -1,0 +1,27 @@
+{
+  "DateTime": "2026-03-26T10:15:30Z",
+  "SaleSoftware": {
+    "ManufacturerID": "adyen",
+    "ApplicationName": "register-app",
+    "SoftwareVersion": "1.0.0",
+    "CertificationCode": "cert-123"
+  },
+  "SaleTerminalData": {
+    "SaleCapabilities": [
+      "CashierDisplay",
+      "CustomerDisplay"
+    ],
+    "TerminalEnvironment": "Attended",
+    "TotalsGroupID": "group-1"
+  },
+  "TrainingModeFlag": true,
+  "OperatorLanguage": "en",
+  "OperatorID": "operator-1",
+  "ShiftNumber": "shift-1",
+  "TokenRequestedType": "Transaction",
+  "CustomerOrderReq": [
+    "Open",
+    "Closed"
+  ],
+  "POISerialNumber": "poi-serial-1"
+}

--- a/src/test/resources/mocks/terminal-api/message-header.json
+++ b/src/test/resources/mocks/terminal-api/message-header.json
@@ -1,0 +1,10 @@
+{
+  "ProtocolVersion": "3.0",
+  "MessageClass": "Service",
+  "MessageCategory": "Payment",
+  "MessageType": "Request",
+  "ServiceID": "service-id",
+  "DeviceID": "device-id",
+  "SaleID": "sale-id",
+  "POIID": "poi-id"
+}

--- a/src/test/resources/mocks/terminal-api/message-reference.json
+++ b/src/test/resources/mocks/terminal-api/message-reference.json
@@ -1,0 +1,7 @@
+{
+  "MessageCategory": "Payment",
+  "ServiceID": "service-id",
+  "DeviceID": "device-id",
+  "SaleID": "sale-id",
+  "POIID": "poi-id"
+}


### PR DESCRIPTION
**Description**

In the scope of JAXB migration, we need some sanity check to verify that the changes will work.
This is not a full complete set, but I sampled a few classes to add coverage.

It would be helpful to get some feedback about the tests and whether we could improve something for the upcoming work.

**Tested scenarios**
- simple serialization and deserialization of some impacted classes
