### PR TITLE
Cloud Device generation adjustments

### DIFF
--- a/src/main/java/com/adyen/model/tapi/AccountType.java
+++ b/src/main/java/com/adyen/model/tapi/AccountType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Type of cardholder account used for the transaction. Allows a cardholder to select the type of
@@ -36,6 +37,8 @@ public enum AccountType {
   SAVINGS("Savings"),
 
   UNIVERSAL("Universal");
+
+  private static final Logger LOG = Logger.getLogger(AccountType.class.getName());
 
   private String value;
 
@@ -60,6 +63,12 @@ public enum AccountType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "AccountType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(AccountType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/Alignment.java
+++ b/src/main/java/com/adyen/model/tapi/Alignment.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets Alignment */
 public enum Alignment {
@@ -24,6 +25,8 @@ public enum Alignment {
   LEFT("Left"),
 
   RIGHT("Right");
+
+  private static final Logger LOG = Logger.getLogger(Alignment.class.getName());
 
   private String value;
 
@@ -48,6 +51,12 @@ public enum Alignment {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "Alignment: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(Alignment.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/CharacterHeight.java
+++ b/src/main/java/com/adyen/model/tapi/CharacterHeight.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets CharacterHeight */
 public enum CharacterHeight {
@@ -22,6 +23,8 @@ public enum CharacterHeight {
   HALF_HEIGHT("HalfHeight"),
 
   SINGLE_HEIGHT("SingleHeight");
+
+  private static final Logger LOG = Logger.getLogger(CharacterHeight.class.getName());
 
   private String value;
 
@@ -46,6 +49,12 @@ public enum CharacterHeight {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "CharacterHeight: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(CharacterHeight.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/CharacterStyle.java
+++ b/src/main/java/com/adyen/model/tapi/CharacterStyle.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets CharacterStyle */
 public enum CharacterStyle {
@@ -24,6 +25,8 @@ public enum CharacterStyle {
   NORMAL("Normal"),
 
   UNDERLINE("Underline");
+
+  private static final Logger LOG = Logger.getLogger(CharacterStyle.class.getName());
 
   private String value;
 
@@ -48,6 +51,12 @@ public enum CharacterStyle {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "CharacterStyle: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(CharacterStyle.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/CharacterWidth.java
+++ b/src/main/java/com/adyen/model/tapi/CharacterWidth.java
@@ -14,12 +14,15 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets CharacterWidth */
 public enum CharacterWidth {
   DOUBLE_WIDTH("DoubleWidth"),
 
   SINGLE_WIDTH("SingleWidth");
+
+  private static final Logger LOG = Logger.getLogger(CharacterWidth.class.getName());
 
   private String value;
 
@@ -44,6 +47,12 @@ public enum CharacterWidth {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "CharacterWidth: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(CharacterWidth.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/Device.java
+++ b/src/main/java/com/adyen/model/tapi/Device.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets Device */
 public enum Device {
@@ -24,6 +25,8 @@ public enum Device {
   CUSTOMER_DISPLAY("CustomerDisplay"),
 
   CUSTOMER_INPUT("CustomerInput");
+
+  private static final Logger LOG = Logger.getLogger(Device.class.getName());
 
   private String value;
 
@@ -48,6 +51,12 @@ public enum Device {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "Device: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(Device.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/DocumentQualifier.java
+++ b/src/main/java/com/adyen/model/tapi/DocumentQualifier.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets DocumentQualifier */
 public enum DocumentQualifier {
@@ -28,6 +29,8 @@ public enum DocumentQualifier {
   SALE_RECEIPT("SaleReceipt"),
 
   VOUCHER("Voucher");
+
+  private static final Logger LOG = Logger.getLogger(DocumentQualifier.class.getName());
 
   private String value;
 
@@ -52,6 +55,12 @@ public enum DocumentQualifier {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "DocumentQualifier: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(DocumentQualifier.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/ErrorCondition.java
+++ b/src/main/java/com/adyen/model/tapi/ErrorCondition.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets ErrorCondition */
 public enum ErrorCondition {
@@ -51,6 +52,8 @@ public enum ErrorCondition {
 
   WRONG_PIN("WrongPIN");
 
+  private static final Logger LOG = Logger.getLogger(ErrorCondition.class.getName());
+
   private String value;
 
   ErrorCondition(String value) {
@@ -74,6 +77,12 @@ public enum ErrorCondition {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "ErrorCondition: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(ErrorCondition.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/EventToNotify.java
+++ b/src/main/java/com/adyen/model/tapi/EventToNotify.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Event the POI notifies to the Sale System. Possible values: * **Abort** * **BeginMaintenance** *
@@ -59,6 +60,8 @@ public enum EventToNotify {
 
   USE_ANOTHER_CARD_FOR_PREAUTH("UseAnotherCardForPreauth");
 
+  private static final Logger LOG = Logger.getLogger(EventToNotify.class.getName());
+
   private String value;
 
   EventToNotify(String value) {
@@ -82,6 +85,12 @@ public enum EventToNotify {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "EventToNotify: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(EventToNotify.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/GlobalStatus.java
+++ b/src/main/java/com/adyen/model/tapi/GlobalStatus.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets GlobalStatus */
 public enum GlobalStatus {
@@ -24,6 +25,8 @@ public enum GlobalStatus {
   OK("OK"),
 
   UNREACHABLE("Unreachable");
+
+  private static final Logger LOG = Logger.getLogger(GlobalStatus.class.getName());
 
   private String value;
 
@@ -48,6 +51,12 @@ public enum GlobalStatus {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "GlobalStatus: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(GlobalStatus.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/IdentificationSupport.java
+++ b/src/main/java/com/adyen/model/tapi/IdentificationSupport.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Support of the loyalty account identification. Allows knowing where and how you have found the
@@ -28,6 +29,8 @@ public enum IdentificationSupport {
   LOYALTY_CARD("LoyaltyCard"),
 
   NO_CARD("NoCard");
+
+  private static final Logger LOG = Logger.getLogger(IdentificationSupport.class.getName());
 
   private String value;
 
@@ -52,6 +55,12 @@ public enum IdentificationSupport {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "IdentificationSupport: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(IdentificationSupport.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/IdentificationType.java
+++ b/src/main/java/com/adyen/model/tapi/IdentificationType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets IdentificationType */
 public enum IdentificationType {
@@ -26,6 +27,8 @@ public enum IdentificationType {
   PAN("PAN"),
 
   PHONE_NUMBER("PhoneNumber");
+
+  private static final Logger LOG = Logger.getLogger(IdentificationType.class.getName());
 
   private String value;
 
@@ -50,6 +53,12 @@ public enum IdentificationType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "IdentificationType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(IdentificationType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/InfoQualify.java
+++ b/src/main/java/com/adyen/model/tapi/InfoQualify.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets InfoQualify */
 public enum InfoQualify {
@@ -36,6 +37,8 @@ public enum InfoQualify {
   STATUS("Status"),
 
   VOUCHER("Voucher");
+
+  private static final Logger LOG = Logger.getLogger(InfoQualify.class.getName());
 
   private String value;
 
@@ -60,6 +63,12 @@ public enum InfoQualify {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "InfoQualify: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(InfoQualify.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/InputCommand.java
+++ b/src/main/java/com/adyen/model/tapi/InputCommand.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets InputCommand */
 public enum InputCommand {
@@ -34,6 +35,8 @@ public enum InputCommand {
   SITE_MANAGER("SiteManager"),
 
   TEXT_STRING("TextString");
+
+  private static final Logger LOG = Logger.getLogger(InputCommand.class.getName());
 
   private String value;
 
@@ -58,6 +61,12 @@ public enum InputCommand {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "InputCommand: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(InputCommand.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/InstalmentType.java
+++ b/src/main/java/com/adyen/model/tapi/InstalmentType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Type of instalment transaction. For requesting an instalment payment transaction. Possible
@@ -25,6 +26,8 @@ public enum InstalmentType {
   EQUAL_INSTALMENTS("EqualInstalments"),
 
   INEQUAL_INSTALMENTS("InequalInstalments");
+
+  private static final Logger LOG = Logger.getLogger(InstalmentType.class.getName());
 
   private String value;
 
@@ -49,6 +52,12 @@ public enum InstalmentType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "InstalmentType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(InstalmentType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/LoyaltyHandling.java
+++ b/src/main/java/com/adyen/model/tapi/LoyaltyHandling.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets LoyaltyHandling */
 public enum LoyaltyHandling {
@@ -26,6 +27,8 @@ public enum LoyaltyHandling {
   PROPOSED("Proposed"),
 
   REQUIRED("Required");
+
+  private static final Logger LOG = Logger.getLogger(LoyaltyHandling.class.getName());
 
   private String value;
 
@@ -50,6 +53,12 @@ public enum LoyaltyHandling {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "LoyaltyHandling: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(LoyaltyHandling.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/MenuEntryTag.java
+++ b/src/main/java/com/adyen/model/tapi/MenuEntryTag.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Characteristics related to the selection of a menu entry. Possible values: * **NonSelectable** *
@@ -27,6 +28,8 @@ public enum MenuEntryTag {
   SELECTABLE("Selectable"),
 
   SUB_MENU("SubMenu");
+
+  private static final Logger LOG = Logger.getLogger(MenuEntryTag.class.getName());
 
   private String value;
 
@@ -51,6 +54,12 @@ public enum MenuEntryTag {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "MenuEntryTag: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(MenuEntryTag.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/MessageCategory.java
+++ b/src/main/java/com/adyen/model/tapi/MessageCategory.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets MessageCategory */
 public enum MessageCategory {
@@ -59,6 +60,8 @@ public enum MessageCategory {
 
   TRANSACTION_STATUS("TransactionStatus");
 
+  private static final Logger LOG = Logger.getLogger(MessageCategory.class.getName());
+
   private String value;
 
   MessageCategory(String value) {
@@ -82,6 +85,12 @@ public enum MessageCategory {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "MessageCategory: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(MessageCategory.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/MessageClass.java
+++ b/src/main/java/com/adyen/model/tapi/MessageClass.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets MessageClass */
 public enum MessageClass {
@@ -22,6 +23,8 @@ public enum MessageClass {
   EVENT("Event"),
 
   SERVICE("Service");
+
+  private static final Logger LOG = Logger.getLogger(MessageClass.class.getName());
 
   private String value;
 
@@ -46,6 +49,12 @@ public enum MessageClass {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "MessageClass: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(MessageClass.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/MessageType.java
+++ b/src/main/java/com/adyen/model/tapi/MessageType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets MessageType */
 public enum MessageType {
@@ -22,6 +23,8 @@ public enum MessageType {
   REQUEST("Request"),
 
   RESPONSE("Response");
+
+  private static final Logger LOG = Logger.getLogger(MessageType.class.getName());
 
   private String value;
 
@@ -46,6 +49,12 @@ public enum MessageType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "MessageType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(MessageType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/OutputFormat.java
+++ b/src/main/java/com/adyen/model/tapi/OutputFormat.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Format of the content to display or print. Display or print device function. Possible values: *
@@ -27,6 +28,8 @@ public enum OutputFormat {
   TEXT("Text"),
 
   XHTML("XHTML");
+
+  private static final Logger LOG = Logger.getLogger(OutputFormat.class.getName());
 
   private String value;
 
@@ -51,6 +54,12 @@ public enum OutputFormat {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "OutputFormat: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(OutputFormat.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/PINFormat.java
+++ b/src/main/java/com/adyen/model/tapi/PINFormat.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets PINFormat */
 public enum PINFormat {
@@ -24,6 +25,8 @@ public enum PINFormat {
   ISO2("ISO2"),
 
   ISO3("ISO3");
+
+  private static final Logger LOG = Logger.getLogger(PINFormat.class.getName());
 
   private String value;
 
@@ -48,6 +51,12 @@ public enum PINFormat {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "PINFormat: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(PINFormat.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/PINRequestType.java
+++ b/src/main/java/com/adyen/model/tapi/PINRequestType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Type of PIN Service. Possible values: * **PINEnter** * **PINVerify** * **PINVerifyOnly** */
 public enum PINRequestType {
@@ -22,6 +23,8 @@ public enum PINRequestType {
   PIN_VERIFY("PINVerify"),
 
   PIN_VERIFY_ONLY("PINVerifyOnly");
+
+  private static final Logger LOG = Logger.getLogger(PINRequestType.class.getName());
 
   private String value;
 
@@ -46,6 +49,12 @@ public enum PINRequestType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "PINRequestType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(PINRequestType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/PaymentInstrumentType.java
+++ b/src/main/java/com/adyen/model/tapi/PaymentInstrumentType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets PaymentInstrumentType */
 public enum PaymentInstrumentType {
@@ -26,6 +27,8 @@ public enum PaymentInstrumentType {
   MOBILE("Mobile"),
 
   STORED_VALUE("StoredValue");
+
+  private static final Logger LOG = Logger.getLogger(PaymentInstrumentType.class.getName());
 
   private String value;
 
@@ -50,6 +53,12 @@ public enum PaymentInstrumentType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "PaymentInstrumentType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(PaymentInstrumentType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/PaymentType.java
+++ b/src/main/java/com/adyen/model/tapi/PaymentType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets PaymentType */
 public enum PaymentType {
@@ -41,6 +42,8 @@ public enum PaymentType {
 
   UPDATE_RESERVATION("UpdateReservation");
 
+  private static final Logger LOG = Logger.getLogger(PaymentType.class.getName());
+
   private String value;
 
   PaymentType(String value) {
@@ -64,6 +67,12 @@ public enum PaymentType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "PaymentType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(PaymentType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/PeriodUnit.java
+++ b/src/main/java/com/adyen/model/tapi/PeriodUnit.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Type of instalment transaction. Possible values: * **Annual** * **Daily** * **Monthly** *
@@ -27,6 +28,8 @@ public enum PeriodUnit {
   MONTHLY("Monthly"),
 
   WEEKLY("Weekly");
+
+  private static final Logger LOG = Logger.getLogger(PeriodUnit.class.getName());
 
   private String value;
 
@@ -51,6 +54,12 @@ public enum PeriodUnit {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "PeriodUnit: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(PeriodUnit.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/PrinterStatus.java
+++ b/src/main/java/com/adyen/model/tapi/PrinterStatus.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Indicates if the printer is working and usable. Possible values: * **NoPaper** * **OK** *
@@ -29,6 +30,8 @@ public enum PrinterStatus {
   PAPER_JAM("PaperJam"),
 
   PAPER_LOW("PaperLow");
+
+  private static final Logger LOG = Logger.getLogger(PrinterStatus.class.getName());
 
   private String value;
 
@@ -53,6 +56,12 @@ public enum PrinterStatus {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "PrinterStatus: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(PrinterStatus.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/ReconciliationType.java
+++ b/src/main/java/com/adyen/model/tapi/ReconciliationType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets ReconciliationType */
 public enum ReconciliationType {
@@ -24,6 +25,8 @@ public enum ReconciliationType {
   PREVIOUS_RECONCILIATION("PreviousReconciliation"),
 
   SALE_RECONCILIATION("SaleReconciliation");
+
+  private static final Logger LOG = Logger.getLogger(ReconciliationType.class.getName());
 
   private String value;
 
@@ -48,6 +51,12 @@ public enum ReconciliationType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "ReconciliationType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(ReconciliationType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/ResponseMode.java
+++ b/src/main/java/com/adyen/model/tapi/ResponseMode.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets ResponseMode */
 public enum ResponseMode {
@@ -24,6 +25,8 @@ public enum ResponseMode {
   PRINT_END("PrintEnd"),
 
   SOUND_END("SoundEnd");
+
+  private static final Logger LOG = Logger.getLogger(ResponseMode.class.getName());
 
   private String value;
 
@@ -48,6 +51,12 @@ public enum ResponseMode {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "ResponseMode: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(ResponseMode.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/Result.java
+++ b/src/main/java/com/adyen/model/tapi/Result.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets Result */
 public enum Result {
@@ -22,6 +23,8 @@ public enum Result {
   PARTIAL("Partial"),
 
   SUCCESS("Success");
+
+  private static final Logger LOG = Logger.getLogger(Result.class.getName());
 
   private String value;
 
@@ -46,6 +49,12 @@ public enum Result {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "Result: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(Result.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/ReversalReason.java
+++ b/src/main/java/com/adyen/model/tapi/ReversalReason.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Reason of the payment or loyalty reversal. Possible values: * **CustCancel** * **Malfunction** *
@@ -27,6 +28,8 @@ public enum ReversalReason {
   MERCHANT_CANCEL("MerchantCancel"),
 
   UNABLE2_COMPL("Unable2Compl");
+
+  private static final Logger LOG = Logger.getLogger(ReversalReason.class.getName());
 
   private String value;
 
@@ -51,6 +54,12 @@ public enum ReversalReason {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "ReversalReason: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(ReversalReason.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/SoundAction.java
+++ b/src/main/java/com/adyen/model/tapi/SoundAction.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets SoundAction */
 public enum SoundAction {
@@ -22,6 +23,8 @@ public enum SoundAction {
   START_SOUND("StartSound"),
 
   STOP_SOUND("StopSound");
+
+  private static final Logger LOG = Logger.getLogger(SoundAction.class.getName());
 
   private String value;
 
@@ -46,6 +49,12 @@ public enum SoundAction {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "SoundAction: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(SoundAction.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/SoundFormat.java
+++ b/src/main/java/com/adyen/model/tapi/SoundFormat.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets SoundFormat */
 public enum SoundFormat {
@@ -22,6 +23,8 @@ public enum SoundFormat {
   SOUND_REF("SoundRef"),
 
   TEXT("Text");
+
+  private static final Logger LOG = Logger.getLogger(SoundFormat.class.getName());
 
   private String value;
 
@@ -46,6 +49,12 @@ public enum SoundFormat {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "SoundFormat: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(SoundFormat.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/StoredValueAccountType.java
+++ b/src/main/java/com/adyen/model/tapi/StoredValueAccountType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets StoredValueAccountType */
 public enum StoredValueAccountType {
@@ -22,6 +23,8 @@ public enum StoredValueAccountType {
   OTHER("Other"),
 
   PHONE_CARD("PhoneCard");
+
+  private static final Logger LOG = Logger.getLogger(StoredValueAccountType.class.getName());
 
   private String value;
 
@@ -46,6 +49,12 @@ public enum StoredValueAccountType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "StoredValueAccountType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(StoredValueAccountType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/StoredValueTransactionType.java
+++ b/src/main/java/com/adyen/model/tapi/StoredValueTransactionType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets StoredValueTransactionType */
 public enum StoredValueTransactionType {
@@ -28,6 +29,8 @@ public enum StoredValueTransactionType {
   REVERSE("Reverse"),
 
   UNLOAD("Unload");
+
+  private static final Logger LOG = Logger.getLogger(StoredValueTransactionType.class.getName());
 
   private String value;
 
@@ -52,6 +55,12 @@ public enum StoredValueTransactionType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "StoredValueTransactionType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(StoredValueTransactionType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/TokenRequestedType.java
+++ b/src/main/java/com/adyen/model/tapi/TokenRequestedType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Type of token replacing the PAN of a payment card to identify the payment mean of the customer.
@@ -24,6 +25,8 @@ public enum TokenRequestedType {
   CUSTOMER("Customer"),
 
   TRANSACTION("Transaction");
+
+  private static final Logger LOG = Logger.getLogger(TokenRequestedType.class.getName());
 
   private String value;
 
@@ -48,6 +51,12 @@ public enum TokenRequestedType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "TokenRequestedType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(TokenRequestedType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/TrackFormat.java
+++ b/src/main/java/com/adyen/model/tapi/TrackFormat.java
@@ -14,12 +14,15 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Magnetic track or magnetic ink characters line. Possible values: * **AAMVA** * **ISO** */
 public enum TrackFormat {
   AAMVA("AAMVA"),
 
   ISO("ISO");
+
+  private static final Logger LOG = Logger.getLogger(TrackFormat.class.getName());
 
   private String value;
 
@@ -44,6 +47,12 @@ public enum TrackFormat {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "TrackFormat: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(TrackFormat.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/TransactionAction.java
+++ b/src/main/java/com/adyen/model/tapi/TransactionAction.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * Action to realise on a transaction. In an &#x60;EnableService&#x60; request message: - Starts a
@@ -26,6 +27,8 @@ public enum TransactionAction {
   ABORT_TRANSACTION("AbortTransaction"),
 
   START_TRANSACTION("StartTransaction");
+
+  private static final Logger LOG = Logger.getLogger(TransactionAction.class.getName());
 
   private String value;
 
@@ -50,6 +53,12 @@ public enum TransactionAction {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "TransactionAction: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(TransactionAction.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/TransactionType.java
+++ b/src/main/java/com/adyen/model/tapi/TransactionType.java
@@ -14,6 +14,7 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets TransactionType */
 public enum TransactionType {
@@ -55,6 +56,8 @@ public enum TransactionType {
 
   UPDATE_RESERVATION("UpdateReservation");
 
+  private static final Logger LOG = Logger.getLogger(TransactionType.class.getName());
+
   private String value;
 
   TransactionType(String value) {
@@ -78,6 +81,12 @@ public enum TransactionType {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "TransactionType: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(TransactionType.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/model/tapi/TypeCode.java
+++ b/src/main/java/com/adyen/model/tapi/TypeCode.java
@@ -14,12 +14,15 @@ package com.adyen.model.tapi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.*;
+import java.util.logging.Logger;
 
 /** Gets or Sets TypeCode */
 public enum TypeCode {
   COMPANY("Company"),
 
   PERSONAL("Personal");
+
+  private static final Logger LOG = Logger.getLogger(TypeCode.class.getName());
 
   private String value;
 
@@ -44,6 +47,12 @@ public enum TypeCode {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    // handling unexpected value
+    LOG.warning(
+        "TypeCode: unexpected enum value '"
+            + value
+            + "' - Supported values are "
+            + Arrays.toString(TypeCode.values()));
+    return null;
   }
 }

--- a/src/main/java/com/adyen/service/clouddevice/CloudDeviceApi.java
+++ b/src/main/java/com/adyen/service/clouddevice/CloudDeviceApi.java
@@ -3,6 +3,7 @@ package com.adyen.service.clouddevice;
 import com.adyen.Client;
 import com.adyen.Service;
 import com.adyen.constants.ApiConstants;
+import com.adyen.model.RequestOptions;
 import com.adyen.model.clouddevice.*;
 import com.adyen.model.clouddevice.CloudDeviceApiAsyncResponse;
 import com.adyen.service.exception.ApiException;
@@ -139,11 +140,11 @@ public class CloudDeviceApi extends Service {
   }
 
   /**
-   * Get a list of connected devices for a merchant account.
+   * Get a list of connected devices
    *
-   * @param merchantAccount The unique identifier of the merchant account.
-   * @return An instance of ConnectedDevicesResponse.
-   * @throws ApiException when an error occurs
+   * @param merchantAccount {@link String } The unique identifier of the merchant account. (required)
+   * @return {@link ConnectedDevicesResponse }
+   * @throws ApiException if fails to make API call
    */
   public ConnectedDevicesResponse getConnectedDevices(String merchantAccount)
       throws ApiException, IOException {
@@ -151,12 +152,13 @@ public class CloudDeviceApi extends Service {
   }
 
   /**
-   * Get a list of connected devices for a merchant account and store.
+   * Get a list of connected devices
    *
-   * @param merchantAccount The unique identifier of the merchant account.
-   * @param store The unique identifier of the store.
-   * @return An instance of ConnectedDevicesResponse.
-   * @throws ApiException when an error occurs
+   * @param merchantAccount {@link String } The unique identifier of the merchant account. (required)
+   * @param store {@link String } Query: The store ID of the store belonging to the merchant account
+   *     specified in the path. (optional)
+   * @return {@link ConnectedDevicesResponse }
+   * @throws ApiException if fails to make API call
    */
   public ConnectedDevicesResponse getConnectedDevices(String merchantAccount, String store)
       throws ApiException, IOException {
@@ -168,18 +170,19 @@ public class CloudDeviceApi extends Service {
     }
     pathParams.put("merchantAccount", merchantAccount);
 
-    Map<String, String> queryParams = null;
+    // Add query params
+    Map<String, String> queryParams = new HashMap<>();
     if (store != null) {
-      queryParams = new HashMap<>();
       queryParams.put("store", store);
     }
 
+    String requestBody = null;
     Resource resource =
         new Resource(this, this.baseURL + "/merchants/{merchantAccount}/connectedDevices", null);
-    String response =
-        resource.request(null, null, ApiConstants.HttpMethod.GET, pathParams, queryParams);
+    String jsonResult =
+        resource.request(requestBody, null, ApiConstants.HttpMethod.GET, pathParams, queryParams);
 
-    return ConnectedDevicesResponse.fromJson(response);
+    return ConnectedDevicesResponse.fromJson(jsonResult);
   }
 
   /**

--- a/src/test/java/com/adyen/serializer/ModelTest.java
+++ b/src/test/java/com/adyen/serializer/ModelTest.java
@@ -12,10 +12,17 @@ import com.adyen.model.checkout.StoredPaymentMethodDetails;
 import com.adyen.model.legalentitymanagement.*;
 import com.adyen.model.management.Connectivity;
 import com.adyen.model.management.TerminalSettings;
+import com.adyen.model.tapi.PaymentRequest;
+import com.adyen.model.tapi.PaymentResponse;
 import com.adyen.model.tapi.Response;
+import com.adyen.model.tapi.Result;
+import com.adyen.model.tapi.SaleData;
+import com.adyen.model.tapi.TransactionIDType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.Month;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.Test;
 
 /** Test model serialization (toJson) and deserialization (fromJson) */
@@ -199,6 +206,85 @@ public class ModelTest {
     assertEquals("7219687191761347", storedPaymentMethodDetails.getStoredPaymentMethodId());
   }
 
+  @Test
+  public void testTapiTimestampDeserialization() throws JsonProcessingException {
+    String json =
+        "{"
+            + "\"Response\":{\"Result\":\"Success\"},"
+            + "\"SaleData\":{"
+            + "  \"SaleTransactionID\":{"
+            + "    \"TransactionID\":\"txn-001\","
+            + "    \"TimeStamp\":\"2024-01-15T10:30:00+01:00\""
+            + "  }"
+            + "},"
+            + "\"POIData\":{"
+            + "  \"POITransactionID\":{"
+            + "    \"TransactionID\":\"poi-txn-001\","
+            + "    \"TimeStamp\":\"2024-01-15T10:30:05+01:00\""
+            + "  }"
+            + "}"
+            + "}";
+
+    PaymentResponse response = PaymentResponse.fromJson(json);
+
+    assertNotNull(response);
+    assertEquals(Result.SUCCESS, response.getResponse().getResult());
+
+    OffsetDateTime saleTimestamp = response.getSaleData().getSaleTransactionID().getTimeStamp();
+    assertNotNull(saleTimestamp);
+    assertEquals(2024, saleTimestamp.getYear());
+    assertEquals(Month.JANUARY, saleTimestamp.getMonth());
+    assertEquals(15, saleTimestamp.getDayOfMonth());
+    assertEquals(10, saleTimestamp.getHour());
+    assertEquals(30, saleTimestamp.getMinute());
+    assertEquals(ZoneOffset.of("+01:00"), saleTimestamp.getOffset());
+
+    OffsetDateTime poiTimestamp = response.getPoiData().getPoITransactionID().getTimeStamp();
+    assertNotNull(poiTimestamp);
+    assertEquals(5, poiTimestamp.getSecond());
+  }
+
+  @Test
+  public void testTapiTimestampSerialization() throws JsonProcessingException {
+    OffsetDateTime timestamp =
+        OffsetDateTime.of(2024, 1, 15, 10, 30, 0, 0, ZoneOffset.of("+01:00"));
+
+    PaymentRequest request =
+        new PaymentRequest()
+            .saleData(
+                new SaleData()
+                    .saleTransactionID(
+                        new TransactionIDType().transactionID("txn-001").timeStamp(timestamp)));
+
+    String json = request.toJson();
+
+    assertNotNull(json);
+    assertTrue(json.contains("\"TimeStamp\":\"2024-01-15T10:30:00+01:00\""));
+    assertTrue(json.contains("\"TransactionID\":\"txn-001\""));
+  }
+
+  @Test
+  public void testTapiPaymentResponseWithUnknownAttribute() throws JsonProcessingException {
+    String json =
+        "{"
+            + "\"Response\":{\"Result\":\"Success\"},"
+            + "\"UnknownField\":\"someValue\","
+            + "\"SaleData\":{"
+            + "  \"SaleTransactionID\":{"
+            + "    \"TransactionID\":\"txn-001\","
+            + "    \"TimeStamp\":\"2024-01-15T10:30:00+01:00\","
+            + "    \"UnknownNestedField\":123"
+            + "  }"
+            + "}"
+            + "}";
+
+    PaymentResponse response = PaymentResponse.fromJson(json);
+
+    assertNotNull(response);
+    assertEquals(Result.SUCCESS, response.getResponse().getResult());
+    assertEquals("txn-001", response.getSaleData().getSaleTransactionID().getTransactionID());
+  }
+
   // test unknown enum value for tapi model
   @Test
   public void testFromJsonTapiResponseWithInvalidEnum() throws JsonProcessingException {
@@ -278,5 +364,10 @@ public class ModelTest {
     // Expectation: 'surcharge' should NOT be present, even though the flag is true.
     // It should only be present if we called setSurcharge().
     assertEquals("{\"connectivity\":{\"simcardStatus\":\"ACTIVATED\"}}", json);
+  }
+
+  @Test
+  public void testTapiEnumFromValueNull() {
+    assertNull(Result.fromValue(null));
   }
 }

--- a/src/test/java/com/adyen/serializer/ModelTest.java
+++ b/src/test/java/com/adyen/serializer/ModelTest.java
@@ -12,6 +12,7 @@ import com.adyen.model.checkout.StoredPaymentMethodDetails;
 import com.adyen.model.legalentitymanagement.*;
 import com.adyen.model.management.Connectivity;
 import com.adyen.model.management.TerminalSettings;
+import com.adyen.model.tapi.Response;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.Month;
 import java.time.ZoneId;
@@ -196,6 +197,22 @@ public class ModelTest {
     assertEquals(
         StoredPaymentMethodDetails.TypeEnum.BCMC_MOBILE, storedPaymentMethodDetails.getType());
     assertEquals("7219687191761347", storedPaymentMethodDetails.getStoredPaymentMethodId());
+  }
+
+  // test unknown enum value for tapi model
+  @Test
+  public void testFromJsonTapiResponseWithInvalidEnum() throws JsonProcessingException {
+    String json =
+        "{\n"
+            + "  \"Result\": \"UNKNOWN_RESULT\",\n"
+            + "  \"AdditionalResponse\": \"some info\"\n"
+            + "}";
+
+    Response response = Response.fromJson(json);
+
+    assertNotNull(response);
+    assertEquals("some info", response.getAdditionalResponse());
+    assertNull(response.getResult());
   }
 
   // test null values are not serialized

--- a/src/test/java/com/adyen/service/clouddevice/CloudDeviceApiTest.java
+++ b/src/test/java/com/adyen/service/clouddevice/CloudDeviceApiTest.java
@@ -175,7 +175,7 @@ public class CloudDeviceApiTest extends BaseTest {
             false,
             null,
             ApiConstants.HttpMethod.GET,
-            null);
+            Map.of());
   }
 
   @Test

--- a/templates-v7/libraries/jersey3/modelEnum.mustache
+++ b/templates-v7/libraries/jersey3/modelEnum.mustache
@@ -1,0 +1,124 @@
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+{{/jackson}}
+{{#gson}}
+import java.io.IOException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+{{/gson}}
+{{#isUri}}
+import java.net.URI;
+{{/isUri}}
+
+/**
+ * {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+ */
+{{#gson}}
+@JsonAdapter({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}
+{{#jsonb}}
+@JsonbTypeSerializer({{datatypeWithEnum}}.Serializer.class)
+@JsonbTypeDeserializer({{datatypeWithEnum}}.Deserializer.class)
+{{/jsonb}}
+{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+{{#allowableValues}}{{#enumVars}}
+{{#enumDescription}}
+  /**
+   * {{.}}
+   */
+{{/enumDescription}}
+{{#withXml}}
+  @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+{{/withXml}}
+  {{{name}}}({{{value}}}){{^-last}},
+{{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+
+  private static final Logger LOG = Logger.getLogger({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.class.getName());
+
+  private {{{dataType}}} value;
+
+  {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+    this.value = value;
+  }
+
+{{#jackson}}
+  @JsonValue
+{{/jackson}}
+  public {{{dataType}}} getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+{{#jackson}}
+  @JsonCreator
+{{/jackson}}
+  public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
+    for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+      if (b.value.{{^isString}}equals{{/isString}}{{#isString}}{{#useEnumCaseInsensitive}}equalsIgnoreCase{{/useEnumCaseInsensitive}}{{^useEnumCaseInsensitive}}equals{{/useEnumCaseInsensitive}}{{/isString}}(value)) {
+        return b;
+      }
+    }
+    // handling unexpected value
+    LOG.warning("{{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}: unexpected enum value '" + value + "' - Supported values are " + Arrays.toString({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.values()));
+    return null;
+  }
+{{#gson}}
+
+  public static class Adapter extends TypeAdapter<{{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}> {
+    @Override
+    public void write(final JsonWriter jsonWriter, final {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} enumeration) throws IOException {
+      jsonWriter.value(enumeration.getValue(){{#isUri}}.toASCIIString(){{/isUri}});
+    }
+
+    @Override
+    public {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} read(final JsonReader jsonReader) throws IOException {
+      {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = {{#isFloat}}(float){{/isFloat}}{{#isUri}}URI.create({{/isUri}}jsonReader.{{#isNumber}}nextString(){{/isNumber}}{{#isInteger}}nextInt(){{/isInteger}}{{#isUri}}nextString()){{/isUri}}{{^isNumber}}{{^isInteger}}{{^isUri}}{{#isFloat}}nextDouble{{/isFloat}}{{^isFloat}}next{{{dataType}}}{{/isFloat}}(){{/isUri}}{{/isInteger}}{{/isNumber}};
+      return {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
+    }
+  }
+{{/gson}}
+{{#jsonb}}
+
+  public static final class Deserializer implements JsonbDeserializer<{{datatypeWithEnum}}> {
+    @Override
+    public {{datatypeWithEnum}} deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+      for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+        if (String.valueOf(b.value).equals(parser.getString())) {
+          return b;
+        }
+      }
+      return null;
+    }
+  }
+
+  public static final class Serializer implements JsonbSerializer<{{datatypeWithEnum}}> {
+    @Override
+    public void serialize({{datatypeWithEnum}} obj, JsonGenerator generator, SerializationContext ctx) {
+      generator.write(obj.value);
+    }
+  }
+{{/jsonb}}
+{{#supportUrlQuery}}
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @param prefix prefix of the query string
+   * @return URL query string
+   */
+  public String toUrlQueryString(String prefix) {
+    if (prefix == null) {
+      prefix = "";
+    }
+
+    return String.format("%s=%s", prefix, this.toString());
+  }
+{{/supportUrlQuery}}
+}


### PR DESCRIPTION
PR to consolidate the Cloud Device generation.

## Findings

- Naming conventions for classes, attributes and enums don't change
- Enum class no longer used the `Type` postfix, from `DeviceType` to `Device` (this is a design decision to align with the content of the spec)
- Several classes have disappeared (this is expected)
- TimeStamp is now `OffsetDateTime` instead of `XMLGregorianCalendar`  (this is expected)
- TAPI can handle unknown enum values and unknown attributes like all other services
- The signatures of the service methods in `CloudDeviceApi` are aligned to the OpenAPI spec

