### PR TITLE
Add TAPI utility helpers for PredefinedContent and SaleToAcquirerData

### DIFF
--- a/src/main/java/com/adyen/util/tapi/PredefinedContentHelper.java
+++ b/src/main/java/com/adyen/util/tapi/PredefinedContentHelper.java
@@ -1,0 +1,148 @@
+package com.adyen.util.tapi;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A helper class to parse and manage the key-value pairs within a PredefinedContent referenceID
+ * string. The referenceID is expected to be in a URL query string format (e.g., {@code
+ * key1=value1&key2=value2}).
+ */
+public final class PredefinedContentHelper {
+
+  private static final String KEY_EVENT = "event";
+  private static final String KEY_TRANSACTION_ID = "TransactionID";
+  private static final String KEY_TIME_STAMP = "TimeStamp";
+
+  /**
+   * Defines the supported events for display notifications within a PredefinedContent reference ID.
+   */
+  public enum DisplayNotificationEvent {
+    TENDER_CREATED,
+    CARD_INSERTED,
+    CARD_PRESENTED,
+    CARD_SWIPED,
+    WAIT_FOR_APP_SELECTION,
+    APPLICATION_SELECTED,
+    ASK_SIGNATURE,
+    CHECK_SIGNATURE,
+    SIGNATURE_CHECKED,
+    WAIT_FOR_PIN,
+    PIN_ENTERED,
+    PRINT_RECEIPT,
+    RECEIPT_PRINTED,
+    CARD_REMOVED,
+    TENDER_FINAL,
+    ASK_DCC,
+    DCC_ACCEPTED,
+    DCC_REJECTED,
+    ASK_GRATUITY,
+    GRATUITY_ENTERED,
+    BALANCE_QUERY_STARTED,
+    BALANCE_QUERY_COMPLETED,
+    LOAD_STARTED,
+    LOAD_COMPLETED,
+    PROVIDE_CARD_DETAILS,
+    CARD_DETAILS_PROVIDED
+  }
+
+  private final Map<String, String> params;
+
+  /**
+   * Constructs a helper instance by parsing the provided reference ID.
+   *
+   * @param referenceId The string from {@code PredefinedContent#getReferenceID()}, expected to be
+   *     in URL query string format.
+   */
+  public PredefinedContentHelper(String referenceId) {
+    this.params = parse(referenceId);
+  }
+
+  /**
+   * Extracts and validates the 'event' value from the reference ID.
+   *
+   * @return An {@link Optional} containing the {@link DisplayNotificationEvent} if it is present
+   *     and valid, otherwise an empty Optional.
+   *     <pre>{@code
+   * PredefinedContentHelper helper = new PredefinedContentHelper("...&event=PIN_ENTERED");
+   * helper.getEvent().ifPresent(event -> System.out.println(event)); // Prints PIN_ENTERED
+   * }</pre>
+   */
+  public Optional<DisplayNotificationEvent> getEvent() {
+    return get(KEY_EVENT)
+        .flatMap(
+            eventValue -> {
+              try {
+                return Optional.of(DisplayNotificationEvent.valueOf(eventValue));
+              } catch (IllegalArgumentException e) {
+                return Optional.empty();
+              }
+            });
+  }
+
+  /**
+   * Gets the transaction ID from the reference ID.
+   *
+   * @return An {@link Optional} containing the TransactionID, or an empty Optional if not present.
+   */
+  public Optional<String> getTransactionId() {
+    return get(KEY_TRANSACTION_ID);
+  }
+
+  /**
+   * Gets the timestamp from the reference ID.
+   *
+   * @return An {@link Optional} containing the TimeStamp, or an empty Optional if not present.
+   */
+  public Optional<String> getTimeStamp() {
+    return get(KEY_TIME_STAMP);
+  }
+
+  /**
+   * Gets the value for a given key from the reference ID.
+   *
+   * @param key The name of the parameter to retrieve.
+   * @return An {@link Optional} containing the parameter's value, or an empty Optional if not
+   *     present.
+   */
+  public Optional<String> get(String key) {
+    return Optional.ofNullable(params.get(key));
+  }
+
+  /**
+   * Returns an unmodifiable view of all parsed parameters.
+   *
+   * @return An unmodifiable {@link Map} of all key-value pairs from the reference ID.
+   */
+  public Map<String, String> toMap() {
+    return Collections.unmodifiableMap(params);
+  }
+
+  /**
+   * Parses a URL query-like string into a map.
+   *
+   * @param referenceId The string to parse.
+   * @return A map of the parsed key-value pairs.
+   */
+  private static Map<String, String> parse(String referenceId) {
+    if (referenceId == null || referenceId.trim().isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> queryPairs = new LinkedHashMap<>();
+    String[] pairs = referenceId.split("&");
+    for (String pair : pairs) {
+      int idx = pair.indexOf("=");
+      if (idx > 0 && idx < pair.length() - 1) {
+        String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+        String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+        queryPairs.put(key, value);
+      }
+    }
+    return queryPairs;
+  }
+}

--- a/src/main/java/com/adyen/util/tapi/PredefinedContentHelper.java
+++ b/src/main/java/com/adyen/util/tapi/PredefinedContentHelper.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Logger;
 
 /**
  * A helper class to parse and manage the key-value pairs within a PredefinedContent referenceID
@@ -14,6 +15,7 @@ import java.util.Optional;
  */
 public final class PredefinedContentHelper {
 
+  private static final Logger LOG = Logger.getLogger(PredefinedContentHelper.class.getName());
   private static final String KEY_EVENT = "event";
   private static final String KEY_TRANSACTION_ID = "TransactionID";
   private static final String KEY_TIME_STAMP = "TimeStamp";
@@ -79,6 +81,7 @@ public final class PredefinedContentHelper {
               try {
                 return Optional.of(DisplayNotificationEvent.valueOf(eventValue));
               } catch (IllegalArgumentException e) {
+                LOG.warning("Unknown DisplayNotificationEvent value: " + eventValue);
                 return Optional.empty();
               }
             });
@@ -130,6 +133,7 @@ public final class PredefinedContentHelper {
    */
   private static Map<String, String> parse(String referenceId) {
     if (referenceId == null || referenceId.trim().isEmpty()) {
+      LOG.warning("referenceId is null or empty, returning empty map");
       return Collections.emptyMap();
     }
 
@@ -140,7 +144,9 @@ public final class PredefinedContentHelper {
       if (idx > 0 && idx < pair.length() - 1) {
         String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
         String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
-        queryPairs.put(key, value);
+        if (queryPairs.put(key, value) != null) {
+          LOG.warning("Duplicate key in referenceId, last value wins: " + key);
+        }
       }
     }
     return queryPairs;

--- a/src/main/java/com/adyen/util/tapi/SaleDataHelper.java
+++ b/src/main/java/com/adyen/util/tapi/SaleDataHelper.java
@@ -3,6 +3,7 @@ package com.adyen.util.tapi;
 import com.adyen.model.tapi.SaleData;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.logging.Logger;
 
 /**
  * A helper class to work with {@code SaleData} from the TAPI model.
@@ -19,6 +20,7 @@ import java.util.Optional;
  */
 public final class SaleDataHelper {
 
+  private static final Logger LOG = Logger.getLogger(SaleDataHelper.class.getName());
   private final SaleData saleData;
 
   /**
@@ -43,10 +45,10 @@ public final class SaleDataHelper {
       return Optional.empty();
     }
     try {
-      return Optional.of(SaleToAcquirerData.parse(raw));
+      return Optional.of(SaleToAcquirerDataParser.parse(raw));
     } catch (Exception e) {
+      LOG.warning("Failed to parse SaleToAcquirerData: " + e.getMessage());
       return Optional.empty();
     }
   }
-
 }

--- a/src/main/java/com/adyen/util/tapi/SaleDataHelper.java
+++ b/src/main/java/com/adyen/util/tapi/SaleDataHelper.java
@@ -1,0 +1,52 @@
+package com.adyen.util.tapi;
+
+import com.adyen.model.tapi.SaleData;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A helper class to work with {@code SaleData} from the TAPI model.
+ *
+ * <p>The {@code SaleToAcquirerData} field supports two formats:
+ *
+ * <ul>
+ *   <li><b>Base64-encoded JSON</b>: a JSON object encoded as a Base64 string.
+ *   <li><b>Key-value pairs</b>: form-encoded pairs using {@code &} as separator (e.g. {@code
+ *       shopperEmail=foo@bar.com&tenderOption=AskGratuity}).
+ * </ul>
+ *
+ * This helper auto-detects the format and parses it into a {@link SaleToAcquirerData} object.
+ */
+public final class SaleDataHelper {
+
+  private final SaleData saleData;
+
+  /**
+   * Constructs a helper instance wrapping the provided {@link SaleData}.
+   *
+   * @param saleData The {@link SaleData} instance to wrap.
+   */
+  public SaleDataHelper(SaleData saleData) {
+    this.saleData = Objects.requireNonNull(saleData, "saleData must not be null");
+  }
+
+  /**
+   * Parses the {@code SaleToAcquirerData} field into a {@link SaleToAcquirerData} object. Supports
+   * both Base64-encoded JSON and form-encoded key-value pair formats.
+   *
+   * @return An {@link Optional} containing the parsed {@link SaleToAcquirerData}, or an empty
+   *     Optional if the field is absent or cannot be parsed.
+   */
+  public Optional<SaleToAcquirerData> getSaleToAcquirerData() {
+    String raw = saleData.getSaleToAcquirerData();
+    if (raw == null || raw.trim().isEmpty()) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(SaleToAcquirerData.parse(raw));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+}

--- a/src/main/java/com/adyen/util/tapi/SaleToAcquirerData.java
+++ b/src/main/java/com/adyen/util/tapi/SaleToAcquirerData.java
@@ -4,13 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Base64;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Logger;
@@ -21,9 +15,6 @@ import java.util.logging.Logger;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SaleToAcquirerData {
-
-  private static final ObjectMapper MAPPER =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   @JsonProperty("metadata")
   private Map<String, String> metadata;
@@ -81,8 +72,7 @@ public class SaleToAcquirerData {
     CARD_ON_FILE("CardOnFile"),
     UNSCHEDULED_CARD_ON_FILE("UnscheduledCardOnFile");
 
-    private static final Logger LOG =
-        Logger.getLogger(RecurringProcessingModel.class.getName());
+    private static final Logger LOG = Logger.getLogger(RecurringProcessingModel.class.getName());
 
     private final String value;
 
@@ -247,144 +237,6 @@ public class SaleToAcquirerData {
     this.redemptionType = redemptionType;
   }
 
-  /**
-   * Encodes this object to a Base64 JSON string.
-   *
-   * @return Base64-encoded JSON representation.
-   */
-  public String toBase64() {
-    try {
-      byte[] json = MAPPER.writeValueAsBytes(this);
-      return Base64.getEncoder().encodeToString(json);
-    } catch (Exception e) {
-      throw new IllegalStateException("Failed to serialize SaleToAcquirerData", e);
-    }
-  }
-
-  /**
-   * Parses a raw {@code SaleToAcquirerData} string into a {@link SaleToAcquirerData} object,
-   * auto-detecting the format. The Base64 string is decoded only once.
-   *
-   * <ul>
-   *   <li>If the string is valid Base64 and decodes to a JSON object, it is parsed as JSON.
-   *   <li>Otherwise it is parsed as form-encoded key-value pairs.
-   * </ul>
-   *
-   * @param raw The raw {@code SaleToAcquirerData} string.
-   * @return Parsed {@link SaleToAcquirerData}.
-   */
-  public static SaleToAcquirerData parse(String raw) {
-    try {
-      byte[] decoded = Base64.getDecoder().decode(raw);
-      if (new String(decoded, StandardCharsets.UTF_8).trim().startsWith("{")) {
-        return MAPPER.readValue(decoded, SaleToAcquirerData.class);
-      }
-    } catch (IllegalArgumentException e) {
-      // not valid Base64 — fall through to key-value parsing
-    } catch (Exception e) {
-      throw new IllegalStateException("Failed to deserialize SaleToAcquirerData", e);
-    }
-    return fromKeyValuePairs(raw);
-  }
-
-  /**
-   * Decodes a Base64 JSON string into a {@link SaleToAcquirerData} object.
-   *
-   * @param base64 Base64-encoded JSON string.
-   * @return Decoded {@link SaleToAcquirerData}.
-   */
-  public static SaleToAcquirerData fromBase64(String base64) {
-    try {
-      byte[] decoded = Base64.getDecoder().decode(base64);
-      return MAPPER.readValue(decoded, SaleToAcquirerData.class);
-    } catch (Exception e) {
-      throw new IllegalStateException("Failed to deserialize SaleToAcquirerData", e);
-    }
-  }
-
-  /**
-   * Parses a form-encoded key-value pair string (e.g. {@code
-   * shopperEmail=foo@bar.com&tenderOption=AskGratuity}) into a {@link SaleToAcquirerData} object.
-   * Metadata fields use dotted notation: {@code metadata.key=value}.
-   *
-   * @param keyValuePairs Form-encoded key-value string using {@code &} as separator.
-   * @return Parsed {@link SaleToAcquirerData}.
-   */
-  public static SaleToAcquirerData fromKeyValuePairs(String keyValuePairs) {
-    SaleToAcquirerData data = new SaleToAcquirerData();
-    Map<String, String> metadata = new HashMap<>();
-    Map<String, String> additionalData = new HashMap<>();
-
-    for (String pair : keyValuePairs.split("&")) {
-      int idx = pair.indexOf('=');
-      if (idx <= 0 || idx >= pair.length() - 1) {
-        continue;
-      }
-      String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
-      String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
-
-      if (key.startsWith("metadata.")) {
-        metadata.put(key.substring("metadata.".length()), value);
-      } else {
-        switch (key) {
-          case "shopperEmail":
-            data.setShopperEmail(value);
-            break;
-          case "shopperReference":
-            data.setShopperReference(value);
-            break;
-          case "shopperStatement":
-            data.setShopperStatement(value);
-            break;
-          case "recurringContract":
-            data.setRecurringContract(value);
-            break;
-          case "recurringDetailName":
-            data.setRecurringDetailName(value);
-            break;
-          case "recurringTokenService":
-            data.setRecurringTokenService(value);
-            break;
-          case "recurringProcessingModel":
-            data.setRecurringProcessingModel(RecurringProcessingModel.fromValue(value));
-            break;
-          case "store":
-            data.setStore(value);
-            break;
-          case "merchantAccount":
-            data.setMerchantAccount(value);
-            break;
-          case "currency":
-            data.setCurrency(value);
-            break;
-          case "tenderOption":
-            data.setTenderOption(value);
-            break;
-          case "authorisationType":
-            data.setAuthorisationType(value);
-            break;
-          case "ssc":
-            data.setSsc(value);
-            break;
-          case "redemptionType":
-            data.setRedemptionType(value);
-            break;
-          default:
-            additionalData.put(key, value);
-            break;
-        }
-      }
-    }
-
-    if (!metadata.isEmpty()) {
-      data.setMetadata(metadata);
-    }
-    if (!additionalData.isEmpty()) {
-      data.setAdditionalData(additionalData);
-    }
-    return data;
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -438,10 +290,9 @@ public class SaleToAcquirerData {
   @Override
   public String toString() {
     try {
-      return MAPPER.writeValueAsString(this);
+      return SaleToAcquirerDataParser.toJson(this);
     } catch (Exception e) {
       return "SaleToAcquirerData{serialization error: " + e.getMessage() + "}";
     }
   }
-
 }

--- a/src/main/java/com/adyen/util/tapi/SaleToAcquirerData.java
+++ b/src/main/java/com/adyen/util/tapi/SaleToAcquirerData.java
@@ -1,0 +1,447 @@
+package com.adyen.util.tapi;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+
+/**
+ * Sale information intended for the Acquirer, decoded from the Base64-encoded JSON string found in
+ * {@code SaleData.SaleToAcquirerData}.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SaleToAcquirerData {
+
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @JsonProperty("metadata")
+  private Map<String, String> metadata;
+
+  @JsonProperty("shopperEmail")
+  private String shopperEmail;
+
+  @JsonProperty("shopperReference")
+  private String shopperReference;
+
+  @JsonProperty("recurringContract")
+  private String recurringContract;
+
+  @JsonProperty("shopperStatement")
+  private String shopperStatement;
+
+  @JsonProperty("recurringDetailName")
+  private String recurringDetailName;
+
+  @JsonProperty("recurringTokenService")
+  private String recurringTokenService;
+
+  @JsonProperty("store")
+  private String store;
+
+  @JsonProperty("merchantAccount")
+  private String merchantAccount;
+
+  @JsonProperty("currency")
+  private String currency;
+
+  @JsonProperty("applicationInfo")
+  private Map<String, Object> applicationInfo;
+
+  @JsonProperty("tenderOption")
+  private String tenderOption;
+
+  @JsonProperty("additionalData")
+  private Map<String, String> additionalData;
+
+  @JsonProperty("authorisationType")
+  private String authorisationType;
+
+  @JsonProperty("ssc")
+  private String ssc;
+
+  @JsonProperty("recurringProcessingModel")
+  private RecurringProcessingModel recurringProcessingModel;
+
+  @JsonProperty("redemptionType")
+  private String redemptionType;
+
+  public enum RecurringProcessingModel {
+    SUBSCRIPTION("Subscription"),
+    CARD_ON_FILE("CardOnFile"),
+    UNSCHEDULED_CARD_ON_FILE("UnscheduledCardOnFile");
+
+    private static final Logger LOG =
+        Logger.getLogger(RecurringProcessingModel.class.getName());
+
+    private final String value;
+
+    RecurringProcessingModel(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @JsonCreator
+    public static RecurringProcessingModel fromValue(String value) {
+      for (RecurringProcessingModel v : values()) {
+        if (v.value.equals(value)) {
+          return v;
+        }
+      }
+      LOG.warning(
+          "RecurringProcessingModel: unexpected enum value '"
+              + value
+              + "' - Supported values are "
+              + Arrays.toString(RecurringProcessingModel.values()));
+      return null;
+    }
+  }
+
+  public Map<String, String> getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(Map<String, String> metadata) {
+    this.metadata = metadata;
+  }
+
+  public String getShopperEmail() {
+    return shopperEmail;
+  }
+
+  public void setShopperEmail(String shopperEmail) {
+    this.shopperEmail = shopperEmail;
+  }
+
+  public String getShopperReference() {
+    return shopperReference;
+  }
+
+  public void setShopperReference(String shopperReference) {
+    this.shopperReference = shopperReference;
+  }
+
+  public String getRecurringContract() {
+    return recurringContract;
+  }
+
+  public void setRecurringContract(String recurringContract) {
+    this.recurringContract = recurringContract;
+  }
+
+  public String getShopperStatement() {
+    return shopperStatement;
+  }
+
+  public void setShopperStatement(String shopperStatement) {
+    this.shopperStatement = shopperStatement;
+  }
+
+  public String getRecurringDetailName() {
+    return recurringDetailName;
+  }
+
+  public void setRecurringDetailName(String recurringDetailName) {
+    this.recurringDetailName = recurringDetailName;
+  }
+
+  public String getRecurringTokenService() {
+    return recurringTokenService;
+  }
+
+  public void setRecurringTokenService(String recurringTokenService) {
+    this.recurringTokenService = recurringTokenService;
+  }
+
+  public String getStore() {
+    return store;
+  }
+
+  public void setStore(String store) {
+    this.store = store;
+  }
+
+  public String getMerchantAccount() {
+    return merchantAccount;
+  }
+
+  public void setMerchantAccount(String merchantAccount) {
+    this.merchantAccount = merchantAccount;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public void setCurrency(String currency) {
+    this.currency = currency;
+  }
+
+  public Map<String, Object> getApplicationInfo() {
+    return applicationInfo;
+  }
+
+  public void setApplicationInfo(Map<String, Object> applicationInfo) {
+    this.applicationInfo = applicationInfo;
+  }
+
+  public String getTenderOption() {
+    return tenderOption;
+  }
+
+  public void setTenderOption(String tenderOption) {
+    this.tenderOption = tenderOption;
+  }
+
+  public Map<String, String> getAdditionalData() {
+    return additionalData;
+  }
+
+  public void setAdditionalData(Map<String, String> additionalData) {
+    this.additionalData = additionalData;
+  }
+
+  public String getAuthorisationType() {
+    return authorisationType;
+  }
+
+  public void setAuthorisationType(String authorisationType) {
+    this.authorisationType = authorisationType;
+  }
+
+  public String getSsc() {
+    return ssc;
+  }
+
+  public void setSsc(String ssc) {
+    this.ssc = ssc;
+  }
+
+  public RecurringProcessingModel getRecurringProcessingModel() {
+    return recurringProcessingModel;
+  }
+
+  public void setRecurringProcessingModel(RecurringProcessingModel recurringProcessingModel) {
+    this.recurringProcessingModel = recurringProcessingModel;
+  }
+
+  public String getRedemptionType() {
+    return redemptionType;
+  }
+
+  public void setRedemptionType(String redemptionType) {
+    this.redemptionType = redemptionType;
+  }
+
+  /**
+   * Encodes this object to a Base64 JSON string.
+   *
+   * @return Base64-encoded JSON representation.
+   */
+  public String toBase64() {
+    try {
+      byte[] json = MAPPER.writeValueAsBytes(this);
+      return Base64.getEncoder().encodeToString(json);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to serialize SaleToAcquirerData", e);
+    }
+  }
+
+  /**
+   * Parses a raw {@code SaleToAcquirerData} string into a {@link SaleToAcquirerData} object,
+   * auto-detecting the format. The Base64 string is decoded only once.
+   *
+   * <ul>
+   *   <li>If the string is valid Base64 and decodes to a JSON object, it is parsed as JSON.
+   *   <li>Otherwise it is parsed as form-encoded key-value pairs.
+   * </ul>
+   *
+   * @param raw The raw {@code SaleToAcquirerData} string.
+   * @return Parsed {@link SaleToAcquirerData}.
+   */
+  public static SaleToAcquirerData parse(String raw) {
+    try {
+      byte[] decoded = Base64.getDecoder().decode(raw);
+      if (new String(decoded, StandardCharsets.UTF_8).trim().startsWith("{")) {
+        return MAPPER.readValue(decoded, SaleToAcquirerData.class);
+      }
+    } catch (IllegalArgumentException e) {
+      // not valid Base64 — fall through to key-value parsing
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to deserialize SaleToAcquirerData", e);
+    }
+    return fromKeyValuePairs(raw);
+  }
+
+  /**
+   * Decodes a Base64 JSON string into a {@link SaleToAcquirerData} object.
+   *
+   * @param base64 Base64-encoded JSON string.
+   * @return Decoded {@link SaleToAcquirerData}.
+   */
+  public static SaleToAcquirerData fromBase64(String base64) {
+    try {
+      byte[] decoded = Base64.getDecoder().decode(base64);
+      return MAPPER.readValue(decoded, SaleToAcquirerData.class);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to deserialize SaleToAcquirerData", e);
+    }
+  }
+
+  /**
+   * Parses a form-encoded key-value pair string (e.g. {@code
+   * shopperEmail=foo@bar.com&tenderOption=AskGratuity}) into a {@link SaleToAcquirerData} object.
+   * Metadata fields use dotted notation: {@code metadata.key=value}.
+   *
+   * @param keyValuePairs Form-encoded key-value string using {@code &} as separator.
+   * @return Parsed {@link SaleToAcquirerData}.
+   */
+  public static SaleToAcquirerData fromKeyValuePairs(String keyValuePairs) {
+    SaleToAcquirerData data = new SaleToAcquirerData();
+    Map<String, String> metadata = new HashMap<>();
+    Map<String, String> additionalData = new HashMap<>();
+
+    for (String pair : keyValuePairs.split("&")) {
+      int idx = pair.indexOf('=');
+      if (idx <= 0 || idx >= pair.length() - 1) {
+        continue;
+      }
+      String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+      String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+
+      if (key.startsWith("metadata.")) {
+        metadata.put(key.substring("metadata.".length()), value);
+      } else {
+        switch (key) {
+          case "shopperEmail":
+            data.setShopperEmail(value);
+            break;
+          case "shopperReference":
+            data.setShopperReference(value);
+            break;
+          case "shopperStatement":
+            data.setShopperStatement(value);
+            break;
+          case "recurringContract":
+            data.setRecurringContract(value);
+            break;
+          case "recurringDetailName":
+            data.setRecurringDetailName(value);
+            break;
+          case "recurringTokenService":
+            data.setRecurringTokenService(value);
+            break;
+          case "recurringProcessingModel":
+            data.setRecurringProcessingModel(RecurringProcessingModel.fromValue(value));
+            break;
+          case "store":
+            data.setStore(value);
+            break;
+          case "merchantAccount":
+            data.setMerchantAccount(value);
+            break;
+          case "currency":
+            data.setCurrency(value);
+            break;
+          case "tenderOption":
+            data.setTenderOption(value);
+            break;
+          case "authorisationType":
+            data.setAuthorisationType(value);
+            break;
+          case "ssc":
+            data.setSsc(value);
+            break;
+          case "redemptionType":
+            data.setRedemptionType(value);
+            break;
+          default:
+            additionalData.put(key, value);
+            break;
+        }
+      }
+    }
+
+    if (!metadata.isEmpty()) {
+      data.setMetadata(metadata);
+    }
+    if (!additionalData.isEmpty()) {
+      data.setAdditionalData(additionalData);
+    }
+    return data;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SaleToAcquirerData that = (SaleToAcquirerData) o;
+    return Objects.equals(metadata, that.metadata)
+        && Objects.equals(shopperEmail, that.shopperEmail)
+        && Objects.equals(shopperReference, that.shopperReference)
+        && Objects.equals(recurringContract, that.recurringContract)
+        && Objects.equals(shopperStatement, that.shopperStatement)
+        && Objects.equals(recurringDetailName, that.recurringDetailName)
+        && Objects.equals(recurringTokenService, that.recurringTokenService)
+        && Objects.equals(store, that.store)
+        && Objects.equals(merchantAccount, that.merchantAccount)
+        && Objects.equals(currency, that.currency)
+        && Objects.equals(applicationInfo, that.applicationInfo)
+        && Objects.equals(tenderOption, that.tenderOption)
+        && Objects.equals(additionalData, that.additionalData)
+        && Objects.equals(authorisationType, that.authorisationType)
+        && Objects.equals(ssc, that.ssc)
+        && Objects.equals(recurringProcessingModel, that.recurringProcessingModel)
+        && Objects.equals(redemptionType, that.redemptionType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        metadata,
+        shopperEmail,
+        shopperReference,
+        recurringContract,
+        shopperStatement,
+        recurringDetailName,
+        recurringTokenService,
+        store,
+        merchantAccount,
+        currency,
+        applicationInfo,
+        tenderOption,
+        additionalData,
+        authorisationType,
+        ssc,
+        recurringProcessingModel,
+        redemptionType);
+  }
+
+  @Override
+  public String toString() {
+    try {
+      return MAPPER.writeValueAsString(this);
+    } catch (Exception e) {
+      return "SaleToAcquirerData{serialization error: " + e.getMessage() + "}";
+    }
+  }
+
+}

--- a/src/main/java/com/adyen/util/tapi/SaleToAcquirerDataParser.java
+++ b/src/main/java/com/adyen/util/tapi/SaleToAcquirerDataParser.java
@@ -1,0 +1,181 @@
+package com.adyen.util.tapi;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Parses and serializes {@link SaleToAcquirerData} objects from/to their wire formats.
+ *
+ * <p>Supports two formats:
+ *
+ * <ul>
+ *   <li><b>Base64-encoded JSON</b>: a JSON object encoded as a Base64 string.
+ *   <li><b>Key-value pairs</b>: form-encoded pairs using {@code &} as separator (e.g. {@code
+ *       shopperEmail=foo@bar.com&tenderOption=AskGratuity}).
+ * </ul>
+ */
+public final class SaleToAcquirerDataParser {
+
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  private SaleToAcquirerDataParser() {}
+
+  /**
+   * Parses a raw {@code SaleToAcquirerData} string, auto-detecting the format.
+   *
+   * <ul>
+   *   <li>If the string is valid Base64 and decodes to a JSON object, it is parsed as JSON.
+   *   <li>Otherwise it is parsed as form-encoded key-value pairs.
+   * </ul>
+   *
+   * @param raw The raw {@code SaleToAcquirerData} string.
+   * @return Parsed {@link SaleToAcquirerData}.
+   */
+  public static SaleToAcquirerData parse(String raw) {
+    try {
+      byte[] decoded = Base64.getDecoder().decode(raw);
+      if (new String(decoded, StandardCharsets.UTF_8).trim().startsWith("{")) {
+        return MAPPER.readValue(decoded, SaleToAcquirerData.class);
+      }
+    } catch (IllegalArgumentException e) {
+      // not valid Base64 — fall through to key-value parsing
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to deserialize SaleToAcquirerData", e);
+    }
+    return fromKeyValuePairs(raw);
+  }
+
+  /**
+   * Decodes a Base64 JSON string into a {@link SaleToAcquirerData} object.
+   *
+   * @param base64 Base64-encoded JSON string.
+   * @return Decoded {@link SaleToAcquirerData}.
+   */
+  public static SaleToAcquirerData fromBase64(String base64) {
+    try {
+      byte[] decoded = Base64.getDecoder().decode(base64);
+      return MAPPER.readValue(decoded, SaleToAcquirerData.class);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to deserialize SaleToAcquirerData", e);
+    }
+  }
+
+  /**
+   * Parses a form-encoded key-value pair string (e.g. {@code
+   * shopperEmail=foo@bar.com&tenderOption=AskGratuity}) into a {@link SaleToAcquirerData} object.
+   * Metadata fields use dotted notation: {@code metadata.key=value}.
+   *
+   * @param keyValuePairs Form-encoded key-value string using {@code &} as separator.
+   * @return Parsed {@link SaleToAcquirerData}.
+   */
+  public static SaleToAcquirerData fromKeyValuePairs(String keyValuePairs) {
+    SaleToAcquirerData data = new SaleToAcquirerData();
+    Map<String, String> metadata = new HashMap<>();
+    Map<String, String> additionalData = new HashMap<>();
+
+    for (String pair : keyValuePairs.split("&")) {
+      int idx = pair.indexOf('=');
+      if (idx <= 0 || idx >= pair.length() - 1) {
+        continue;
+      }
+      String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+      String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+
+      if (key.startsWith("metadata.")) {
+        metadata.put(key.substring("metadata.".length()), value);
+      } else {
+        switch (key) {
+          case "shopperEmail":
+            data.setShopperEmail(value);
+            break;
+          case "shopperReference":
+            data.setShopperReference(value);
+            break;
+          case "shopperStatement":
+            data.setShopperStatement(value);
+            break;
+          case "recurringContract":
+            data.setRecurringContract(value);
+            break;
+          case "recurringDetailName":
+            data.setRecurringDetailName(value);
+            break;
+          case "recurringTokenService":
+            data.setRecurringTokenService(value);
+            break;
+          case "recurringProcessingModel":
+            data.setRecurringProcessingModel(
+                SaleToAcquirerData.RecurringProcessingModel.fromValue(value));
+            break;
+          case "store":
+            data.setStore(value);
+            break;
+          case "merchantAccount":
+            data.setMerchantAccount(value);
+            break;
+          case "currency":
+            data.setCurrency(value);
+            break;
+          case "tenderOption":
+            data.setTenderOption(value);
+            break;
+          case "authorisationType":
+            data.setAuthorisationType(value);
+            break;
+          case "ssc":
+            data.setSsc(value);
+            break;
+          case "redemptionType":
+            data.setRedemptionType(value);
+            break;
+          default:
+            additionalData.put(key, value);
+            break;
+        }
+      }
+    }
+
+    if (!metadata.isEmpty()) {
+      data.setMetadata(metadata);
+    }
+    if (!additionalData.isEmpty()) {
+      data.setAdditionalData(additionalData);
+    }
+    return data;
+  }
+
+  /**
+   * Serializes a {@link SaleToAcquirerData} object to a JSON string.
+   *
+   * @param data The object to serialize.
+   * @return JSON string representation.
+   */
+  public static String toJson(SaleToAcquirerData data) {
+    try {
+      return MAPPER.writeValueAsString(data);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to serialize SaleToAcquirerData", e);
+    }
+  }
+
+  /**
+   * Encodes a {@link SaleToAcquirerData} object to a Base64 JSON string.
+   *
+   * @param data The object to encode.
+   * @return Base64-encoded JSON representation.
+   */
+  public static String toBase64(SaleToAcquirerData data) {
+    try {
+      byte[] json = MAPPER.writeValueAsBytes(data);
+      return Base64.getEncoder().encodeToString(json);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to serialize SaleToAcquirerData", e);
+    }
+  }
+}

--- a/src/test/java/com/adyen/util/tapi/PredefinedContentHelperTest.java
+++ b/src/test/java/com/adyen/util/tapi/PredefinedContentHelperTest.java
@@ -86,6 +86,16 @@ public class PredefinedContentHelperTest {
   }
 
   @Test
+  public void testShouldUseLastValueForDuplicateKey() {
+    PredefinedContentHelper helper = new PredefinedContentHelper("foo=first&foo=second");
+
+    Optional<String> foo = helper.get("foo");
+    assertTrue(foo.isPresent(), "Value for 'foo' should be present");
+    assertEquals("second", foo.get(), "Last value should win for duplicate keys");
+    assertEquals(1, helper.toMap().size(), "Duplicate keys should be collapsed into one entry");
+  }
+
+  @Test
   public void testShouldHandleNullReferenceId() {
     PredefinedContentHelper helper = new PredefinedContentHelper(null);
 

--- a/src/test/java/com/adyen/util/tapi/PredefinedContentHelperTest.java
+++ b/src/test/java/com/adyen/util/tapi/PredefinedContentHelperTest.java
@@ -1,0 +1,97 @@
+package com.adyen.util.tapi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link PredefinedContentHelper}. */
+public class PredefinedContentHelperTest {
+
+  @Test
+  public void testShouldExtractValidEvent() {
+    String referenceId =
+        "TransactionID=oLkO001517998574000&TimeStamp=2018-02-07T10%3a16%3a14.000Z&event=PIN_ENTERED";
+    PredefinedContentHelper helper = new PredefinedContentHelper(referenceId);
+
+    Optional<PredefinedContentHelper.DisplayNotificationEvent> event = helper.getEvent();
+    assertTrue(event.isPresent(), "Event should be present");
+    assertEquals(PredefinedContentHelper.DisplayNotificationEvent.PIN_ENTERED, event.get());
+  }
+
+  @Test
+  public void testShouldReturnEmptyForInvalidEvent() {
+    PredefinedContentHelper helper = new PredefinedContentHelper("event=INVALID_EVENT");
+
+    assertFalse(helper.getEvent().isPresent(), "Event should not be present for invalid value");
+  }
+
+  @Test
+  public void testShouldExtractTransactionId() {
+    PredefinedContentHelper helper =
+        new PredefinedContentHelper(
+            "TransactionID=12345&TimeStamp=2018-02-07T10%3a16%3a14.000Z&event=PIN_ENTERED");
+
+    Optional<String> transactionId = helper.getTransactionId();
+    assertTrue(transactionId.isPresent(), "TransactionID should be present");
+    assertEquals("12345", transactionId.get());
+  }
+
+  @Test
+  public void testShouldExtractTimeStamp() {
+    PredefinedContentHelper helper = new PredefinedContentHelper("TimeStamp=2024-07-11T12:00:00Z");
+
+    Optional<String> timeStamp = helper.getTimeStamp();
+    assertTrue(timeStamp.isPresent(), "TimeStamp should be present");
+    assertEquals("2024-07-11T12:00:00Z", timeStamp.get());
+  }
+
+  @Test
+  public void testShouldExtractArbitraryKey() {
+    PredefinedContentHelper helper = new PredefinedContentHelper("foo=bar&baz=qux");
+
+    Optional<String> foo = helper.get("foo");
+    assertTrue(foo.isPresent(), "Value for 'foo' should be present");
+    assertEquals("bar", foo.get());
+
+    Optional<String> baz = helper.get("baz");
+    assertTrue(baz.isPresent(), "Value for 'baz' should be present");
+    assertEquals("qux", baz.get());
+
+    assertFalse(helper.get("missing").isPresent(), "Value for 'missing' should not be present");
+  }
+
+  @Test
+  public void testShouldConvertParamsToMap() {
+    PredefinedContentHelper helper = new PredefinedContentHelper("a=1&b=2&event=WAIT_FOR_PIN");
+
+    Map<String, String> map = helper.toMap();
+    assertEquals(3, map.size());
+    assertEquals("1", map.get("a"));
+    assertEquals("2", map.get("b"));
+    assertEquals("WAIT_FOR_PIN", map.get("event"));
+  }
+
+  @Test
+  public void testShouldHandleEmptyReferenceId() {
+    PredefinedContentHelper helper = new PredefinedContentHelper("");
+
+    assertFalse(helper.getEvent().isPresent());
+    assertFalse(helper.getTransactionId().isPresent());
+    assertFalse(helper.getTimeStamp().isPresent());
+    assertTrue(helper.toMap().isEmpty());
+  }
+
+  @Test
+  public void testShouldHandleNullReferenceId() {
+    PredefinedContentHelper helper = new PredefinedContentHelper(null);
+
+    assertFalse(helper.getEvent().isPresent());
+    assertFalse(helper.getTransactionId().isPresent());
+    assertFalse(helper.getTimeStamp().isPresent());
+    assertTrue(helper.toMap().isEmpty());
+  }
+}

--- a/src/test/java/com/adyen/util/tapi/SaleDataHelperTest.java
+++ b/src/test/java/com/adyen/util/tapi/SaleDataHelperTest.java
@@ -1,0 +1,127 @@
+package com.adyen.util.tapi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.adyen.model.tapi.SaleData;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link SaleDataHelper}. */
+public class SaleDataHelperTest {
+
+  @Test
+  public void testShouldDecodeSaleToAcquirerData() {
+    SaleToAcquirerData original = new SaleToAcquirerData();
+    original.setMerchantAccount("TestMerchant");
+    original.setStore("TestStore");
+    String base64 = original.toBase64();
+
+    SaleData saleData = new SaleData().saleToAcquirerData(base64);
+    SaleDataHelper helper = new SaleDataHelper(saleData);
+
+    Optional<SaleToAcquirerData> result = helper.getSaleToAcquirerData();
+    assertTrue(result.isPresent(), "SaleToAcquirerData should be present");
+    assertEquals("TestMerchant", result.get().getMerchantAccount());
+    assertEquals("TestStore", result.get().getStore());
+  }
+
+  @Test
+  public void testShouldDecodeRecurringProcessingModel() {
+    SaleToAcquirerData original = new SaleToAcquirerData();
+    original.setRecurringProcessingModel(SaleToAcquirerData.RecurringProcessingModel.CARD_ON_FILE);
+    String base64 = original.toBase64();
+
+    SaleDataHelper helper = new SaleDataHelper(new SaleData().saleToAcquirerData(base64));
+
+    Optional<SaleToAcquirerData> result = helper.getSaleToAcquirerData();
+    assertTrue(result.isPresent());
+    assertEquals(
+        SaleToAcquirerData.RecurringProcessingModel.CARD_ON_FILE,
+        result.get().getRecurringProcessingModel());
+  }
+
+  @Test
+  public void testShouldThrowOnNullSaleData() {
+    assertThrows(NullPointerException.class, () -> new SaleDataHelper(null));
+  }
+
+  @Test
+  public void testShouldSkipEmptyValuesInKeyValuePairs() {
+    // key= (empty value) should be silently skipped
+    String kvString = "store=myStore&emptyKey=&merchantAccount=myMerchant";
+    SaleDataHelper helper = new SaleDataHelper(new SaleData().saleToAcquirerData(kvString));
+
+    Optional<SaleToAcquirerData> result = helper.getSaleToAcquirerData();
+    assertTrue(result.isPresent());
+    assertEquals("myStore", result.get().getStore());
+    assertEquals("myMerchant", result.get().getMerchantAccount());
+    assertFalse(
+        result.get().getAdditionalData() != null
+            && result.get().getAdditionalData().containsKey("emptyKey"),
+        "Empty-value key should be skipped");
+  }
+
+  @Test
+  public void testShouldReturnEmptyWhenFieldIsNull() {
+    SaleData saleData = new SaleData();
+    SaleDataHelper helper = new SaleDataHelper(saleData);
+
+    assertFalse(helper.getSaleToAcquirerData().isPresent(), "Should be empty when field is null");
+  }
+
+  @Test
+  public void testShouldReturnEmptyWhenFieldIsBlank() {
+    SaleData saleData = new SaleData().saleToAcquirerData("   ");
+    SaleDataHelper helper = new SaleDataHelper(saleData);
+
+    assertFalse(helper.getSaleToAcquirerData().isPresent(), "Should be empty when field is blank");
+  }
+
+  @Test
+  public void testShouldParseInvalidBase64AsKeyValuePairs() {
+    // Not valid Base64, but valid as key-value pairs — should fall back to key-value parsing
+    SaleData saleData = new SaleData().saleToAcquirerData("store=myStore&merchantAccount=myMerchant");
+    SaleDataHelper helper = new SaleDataHelper(saleData);
+
+    Optional<SaleToAcquirerData> result = helper.getSaleToAcquirerData();
+    assertTrue(result.isPresent(), "Should parse as key-value pairs when not valid Base64");
+    assertEquals("myStore", result.get().getStore());
+    assertEquals("myMerchant", result.get().getMerchantAccount());
+  }
+
+  @Test
+  public void testShouldParseKeyValuePairFormat() {
+    String kvString =
+        "shopperEmail=S.Hopper%40example.com&shopperReference=CUST01_34582"
+            + "&shopperStatement=Book+shop&tenderOption=ReceiptHandler,AskGratuity"
+            + "&metadata.employeeNumber=1";
+
+    SaleData saleData = new SaleData().saleToAcquirerData(kvString);
+    SaleDataHelper helper = new SaleDataHelper(saleData);
+
+    Optional<SaleToAcquirerData> result = helper.getSaleToAcquirerData();
+    assertTrue(result.isPresent(), "SaleToAcquirerData should be present for key-value format");
+    assertEquals("S.Hopper@example.com", result.get().getShopperEmail());
+    assertEquals("CUST01_34582", result.get().getShopperReference());
+    assertEquals("Book shop", result.get().getShopperStatement());
+    assertEquals("ReceiptHandler,AskGratuity", result.get().getTenderOption());
+    assertEquals("1", result.get().getMetadata().get("employeeNumber"));
+  }
+
+  @Test
+  public void testShouldParseKeyValuePairWithAdditionalData() {
+    String kvString = "merchantAccount=TestMerchant&store=TestStore&customKey=customValue";
+
+    SaleData saleData = new SaleData().saleToAcquirerData(kvString);
+    SaleDataHelper helper = new SaleDataHelper(saleData);
+
+    Optional<SaleToAcquirerData> result = helper.getSaleToAcquirerData();
+    assertTrue(result.isPresent());
+    assertEquals("TestMerchant", result.get().getMerchantAccount());
+    assertEquals("TestStore", result.get().getStore());
+    assertEquals("customValue", result.get().getAdditionalData().get("customKey"));
+  }
+}

--- a/src/test/java/com/adyen/util/tapi/SaleDataHelperTest.java
+++ b/src/test/java/com/adyen/util/tapi/SaleDataHelperTest.java
@@ -17,7 +17,7 @@ public class SaleDataHelperTest {
     SaleToAcquirerData original = new SaleToAcquirerData();
     original.setMerchantAccount("TestMerchant");
     original.setStore("TestStore");
-    String base64 = original.toBase64();
+    String base64 = SaleToAcquirerDataParser.toBase64(original);
 
     SaleData saleData = new SaleData().saleToAcquirerData(base64);
     SaleDataHelper helper = new SaleDataHelper(saleData);
@@ -32,7 +32,7 @@ public class SaleDataHelperTest {
   public void testShouldDecodeRecurringProcessingModel() {
     SaleToAcquirerData original = new SaleToAcquirerData();
     original.setRecurringProcessingModel(SaleToAcquirerData.RecurringProcessingModel.CARD_ON_FILE);
-    String base64 = original.toBase64();
+    String base64 = SaleToAcquirerDataParser.toBase64(original);
 
     SaleDataHelper helper = new SaleDataHelper(new SaleData().saleToAcquirerData(base64));
 
@@ -83,7 +83,8 @@ public class SaleDataHelperTest {
   @Test
   public void testShouldParseInvalidBase64AsKeyValuePairs() {
     // Not valid Base64, but valid as key-value pairs — should fall back to key-value parsing
-    SaleData saleData = new SaleData().saleToAcquirerData("store=myStore&merchantAccount=myMerchant");
+    SaleData saleData =
+        new SaleData().saleToAcquirerData("store=myStore&merchantAccount=myMerchant");
     SaleDataHelper helper = new SaleDataHelper(saleData);
 
     Optional<SaleToAcquirerData> result = helper.getSaleToAcquirerData();

--- a/src/test/java/com/adyen/util/tapi/SaleToAcquirerDataParserTest.java
+++ b/src/test/java/com/adyen/util/tapi/SaleToAcquirerDataParserTest.java
@@ -1,0 +1,159 @@
+package com.adyen.util.tapi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link SaleToAcquirerDataParser}. */
+public class SaleToAcquirerDataParserTest {
+
+  @Test
+  public void testParseBase64Json() {
+    String json =
+        "{\"shopperEmail\":\"test@example.com\",\"tenderOption\":\"AskGratuity\",\"currency\":\"EUR\"}";
+    String base64 = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+
+    SaleToAcquirerData result = SaleToAcquirerDataParser.parse(base64);
+
+    assertEquals("test@example.com", result.getShopperEmail());
+    assertEquals("AskGratuity", result.getTenderOption());
+    assertEquals("EUR", result.getCurrency());
+  }
+
+  @Test
+  public void testParseKeyValuePairs() {
+    String kvp = "shopperEmail=test@example.com&tenderOption=AskGratuity&currency=EUR";
+
+    SaleToAcquirerData result = SaleToAcquirerDataParser.parse(kvp);
+
+    assertEquals("test@example.com", result.getShopperEmail());
+    assertEquals("AskGratuity", result.getTenderOption());
+    assertEquals("EUR", result.getCurrency());
+  }
+
+  @Test
+  public void testFromBase64() {
+    String json = "{\"shopperReference\":\"ref123\",\"merchantAccount\":\"TestMerchant\"}";
+    String base64 = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+
+    SaleToAcquirerData result = SaleToAcquirerDataParser.fromBase64(base64);
+
+    assertEquals("ref123", result.getShopperReference());
+    assertEquals("TestMerchant", result.getMerchantAccount());
+  }
+
+  @Test
+  public void testFromBase64InvalidThrows() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> SaleToAcquirerDataParser.fromBase64("not-valid-base64!!"));
+  }
+
+  @Test
+  public void testFromKeyValuePairsAllKnownFields() {
+    String kvp =
+        "shopperEmail=a@b.com"
+            + "&shopperReference=ref1"
+            + "&shopperStatement=stmt"
+            + "&recurringContract=RECURRING"
+            + "&recurringDetailName=detailName"
+            + "&recurringTokenService=tokenSvc"
+            + "&recurringProcessingModel=Subscription"
+            + "&store=myStore"
+            + "&merchantAccount=merchant"
+            + "&currency=USD"
+            + "&tenderOption=AskGratuity"
+            + "&authorisationType=PreAuth"
+            + "&ssc=sscVal"
+            + "&redemptionType=redeemType";
+
+    SaleToAcquirerData result = SaleToAcquirerDataParser.fromKeyValuePairs(kvp);
+
+    assertEquals("a@b.com", result.getShopperEmail());
+    assertEquals("ref1", result.getShopperReference());
+    assertEquals("stmt", result.getShopperStatement());
+    assertEquals("RECURRING", result.getRecurringContract());
+    assertEquals("detailName", result.getRecurringDetailName());
+    assertEquals("tokenSvc", result.getRecurringTokenService());
+    assertEquals(
+        SaleToAcquirerData.RecurringProcessingModel.SUBSCRIPTION,
+        result.getRecurringProcessingModel());
+    assertEquals("myStore", result.getStore());
+    assertEquals("merchant", result.getMerchantAccount());
+    assertEquals("USD", result.getCurrency());
+    assertEquals("AskGratuity", result.getTenderOption());
+    assertEquals("PreAuth", result.getAuthorisationType());
+    assertEquals("sscVal", result.getSsc());
+    assertEquals("redeemType", result.getRedemptionType());
+  }
+
+  @Test
+  public void testFromKeyValuePairsMetadata() {
+    String kvp = "metadata.key1=value1&metadata.key2=value2";
+
+    SaleToAcquirerData result = SaleToAcquirerDataParser.fromKeyValuePairs(kvp);
+
+    assertNotNull(result.getMetadata());
+    assertEquals("value1", result.getMetadata().get("key1"));
+    assertEquals("value2", result.getMetadata().get("key2"));
+  }
+
+  @Test
+  public void testFromKeyValuePairsUnknownKeysGoToAdditionalData() {
+    String kvp = "shopperEmail=a@b.com&unknownField=someValue";
+
+    SaleToAcquirerData result = SaleToAcquirerDataParser.fromKeyValuePairs(kvp);
+
+    assertEquals("a@b.com", result.getShopperEmail());
+    assertNotNull(result.getAdditionalData());
+    assertEquals("someValue", result.getAdditionalData().get("unknownField"));
+  }
+
+  @Test
+  public void testFromKeyValuePairsUrlEncoded() {
+    String kvp = "shopperEmail=test%40example.com&tenderOption=Ask%20Gratuity";
+
+    SaleToAcquirerData result = SaleToAcquirerDataParser.fromKeyValuePairs(kvp);
+
+    assertEquals("test@example.com", result.getShopperEmail());
+    assertEquals("Ask Gratuity", result.getTenderOption());
+  }
+
+  @Test
+  public void testFromKeyValuePairsMalformedPairsIgnored() {
+    String kvp = "shopperEmail=a@b.com&malformed&=nokey&validkey=";
+
+    SaleToAcquirerData result = SaleToAcquirerDataParser.fromKeyValuePairs(kvp);
+
+    assertEquals("a@b.com", result.getShopperEmail());
+    assertNull(result.getAdditionalData());
+  }
+
+  @Test
+  public void testToBase64AndRoundTrip() {
+    SaleToAcquirerData data = new SaleToAcquirerData();
+    data.setShopperEmail("round@trip.com");
+    data.setCurrency("GBP");
+
+    String base64 = SaleToAcquirerDataParser.toBase64(data);
+    SaleToAcquirerData restored = SaleToAcquirerDataParser.fromBase64(base64);
+
+    assertEquals(data, restored);
+  }
+
+  @Test
+  public void testToJson() {
+    SaleToAcquirerData data = new SaleToAcquirerData();
+    data.setShopperEmail("json@test.com");
+
+    String json = SaleToAcquirerDataParser.toJson(data);
+
+    assertTrue(json.contains("\"shopperEmail\":\"json@test.com\""));
+  }
+}


### PR DESCRIPTION
## Summary

Introduces hand-written utility helpers in `com.adyen.util.tapi` to work with fields from the auto-generated TAPI models that require additional parsing logic:

- `PredefinedContent.ReferenceID` string  with URL query string format 
- `SaleData.SaleToAcquirerData` string with either JSON or key-value pairs

### New classes

**`PredefinedContentHelper`**
Parses the `PredefinedContent.ReferenceID` URL query string into typed accessors: `getEvent()`, `getTransactionId()`, `getTimeStamp()`, and `get(key)`.

**`SaleToAcquirerData`**
A Jackson-based POJO representing the decoded acquirer data. Supports both formats described in the [Adyen docs](https://docs.adyen.com/point-of-sale/add-data):
- Base64-encoded JSON (`fromBase64`)
- Form-encoded key-value pairs (`fromKeyValuePairs`)

**`SaleDataHelper`**
Wraps a `tapi.SaleData` instance and exposes `getSaleToAcquirerData()`, auto-detecting the format of the underlying string.

### Notes
- All helpers live outside `com.adyen.model.tapi` which is auto-generated from the OpenAPI spec
- No dependency on the legacy `com.adyen.model.terminal` package
- Uses `java.util.Base64` and Jackson throughout, consistent with the rest of the TAPI stack