### PR TITLE
Add Cloud Device API integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/target/**
 .DS_Store
 .vscode
+src/test/resources/config.properties

--- a/src/main/java/com/adyen/service/clouddevice/EncryptedCloudDeviceApi.java
+++ b/src/main/java/com/adyen/service/clouddevice/EncryptedCloudDeviceApi.java
@@ -126,8 +126,15 @@ public class EncryptedCloudDeviceApi extends Service {
     CloudDeviceApiSecuredResponse cloudDeviceApiSecuredResponse =
         CloudDeviceApiSecuredResponse.fromJson(response);
 
+    SaleToPOISecuredMessage saleToPOISecuredResponse =
+        cloudDeviceApiSecuredResponse.getSaleToPOIResponse();
+    if (saleToPOISecuredResponse == null || saleToPOISecuredResponse.getNexoBlob() == null) {
+      // Terminal returned an unencrypted error response (e.g. terminal unreachable)
+      return CloudDeviceApiResponse.fromJson(response);
+    }
+
     return CloudDeviceApiResponse.fromJson(
-        nexoSecurityManager.decrypt(cloudDeviceApiSecuredResponse.getSaleToPOIResponse()));
+        nexoSecurityManager.decrypt(saleToPOISecuredResponse));
   }
 
   /**
@@ -190,7 +197,12 @@ public class EncryptedCloudDeviceApi extends Service {
       // Error response: an encrypted EventNotification wrapped in a SaleToPOIRequest envelope.
       // Decrypt it and surface the SaleToPOIRequest to the caller.
       CloudDeviceApiSecuredRequest encryptedError = CloudDeviceApiSecuredRequest.fromJson(response);
-      String decryptedJson = nexoSecurityManager.decrypt(encryptedError.getSaleToPOIRequest());
+      SaleToPOISecuredMessage encryptedErrorRequest = encryptedError.getSaleToPOIRequest();
+      if (encryptedErrorRequest == null || encryptedErrorRequest.getNexoBlob() == null) {
+        // Terminal returned an unencrypted error response (e.g. terminal unreachable)
+        return CloudDeviceApiAsyncResponse.fromJson(response);
+      }
+      String decryptedJson = nexoSecurityManager.decrypt(encryptedErrorRequest);
       CloudDeviceApiAsyncResponse errorResponse =
           CloudDeviceApiAsyncResponse.fromJson(decryptedJson);
       cloudDeviceApiAsyncResponse.setSaleToPOIRequest(errorResponse.getSaleToPOIRequest());

--- a/src/test/java/com/adyen/BaseIntegrationTest.java
+++ b/src/test/java/com/adyen/BaseIntegrationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Adyen Java API Library
+ *
+ * Copyright (c) 2025 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+package com.adyen;
+
+import com.adyen.enums.Environment;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Base class for Integration tests
+ *
+ * <p>Define in src/test/resources the configuration for the tests
+ *
+ * <p>``` ADYEN_API_KEY= ADYEN_MERCHANT_ACCOUNT= ADYEN_TERMINAL_DEVICE_ID=
+ * ADYEN_TERMINAL_DEVICE_KEY_IDENTIFIER= ADYEN_TERMINAL_DEVICE_PASSPHRASE= ```
+ */
+public class BaseIntegrationTest {
+
+  private static Properties properties = null;
+
+  protected Client getClient() {
+    return new Client(new Config().apiKey(getApiKey()).environment(Environment.TEST));
+  }
+
+  protected String getApiKey() {
+    return getProperty("ADYEN_API_KEY");
+  }
+
+  protected String getMerchantAccount() {
+    return getProperty("ADYEN_MERCHANT_ACCOUNT");
+  }
+
+  protected String getTerminalDeviceId() {
+    return getProperty("ADYEN_TERMINAL_DEVICE_ID");
+  }
+
+  protected String getTerminalDeviceKeyIdentifier() {
+    return getProperty("ADYEN_TERMINAL_DEVICE_KEY_IDENTIFIER");
+  }
+
+  protected String getTerminalDevicePassphrase() {
+    return getProperty("ADYEN_TERMINAL_DEVICE_PASSPHRASE");
+  }
+
+  private Properties getProperties() {
+    if (properties == null) {
+      properties = new Properties();
+      try (InputStream inputStream =
+          BaseIntegrationTest.class.getClassLoader().getResourceAsStream("config.properties")) {
+        if (inputStream != null) {
+          properties.load(inputStream);
+        }
+      } catch (IOException e) {
+        // Do nothing, properties will be empty
+      }
+    }
+
+    return properties;
+  }
+
+  private String getProperty(String name) {
+    String property = System.getenv(name);
+
+    if (property != null && !property.isEmpty()) {
+      return property;
+    }
+    property = getProperties().getProperty(name);
+
+    if (property == null || property.isEmpty()) {
+      throw new RuntimeException("Property " + name + " not defined");
+    }
+
+    return property;
+  }
+}

--- a/src/test/java/com/adyen/service/clouddevice/CloudDeviceApiTerminalIT.java
+++ b/src/test/java/com/adyen/service/clouddevice/CloudDeviceApiTerminalIT.java
@@ -1,0 +1,181 @@
+package com.adyen.service.clouddevice;
+
+import com.adyen.BaseIntegrationTest;
+import com.adyen.model.clouddevice.*;
+import com.adyen.model.tapi.*;
+import com.adyen.security.clouddevice.EncryptionCredentialDetails;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verify Terminal integration: tests to send API requests to the Cloud Device API and test the
+ * Terminal responds as expected.
+ *
+ * <p>Don't forget to:
+ *
+ * <ul>
+ *   <li>Enable the terminal
+ *   <li>Enable the test to run (by removing/commenting the {@code @Disabled} annotation)
+ *   <li>Set required variables by creating {@code src/test/resources/config.properties}:
+ * </ul>
+ *
+ * <pre>{@code
+ * # Example of config.properties
+ * ADYEN_API_KEY=
+ * ADYEN_MERCHANT_ACCOUNT=MyMerchantAccount
+ * ADYEN_TERMINAL_DEVICE_ID=V400m-1234567890
+ * ADYEN_TERMINAL_DEVICE_KEY_IDENTIFIER=
+ * ADYEN_TERMINAL_DEVICE_PASSPHRASE=
+ * }</pre>
+ *
+ * <ul>
+ *   <li>Run one test at a time with {@code mvn test -Dtest=CloudDeviceApiTerminalIT#sendSync}
+ *   <li>Disable the test again
+ * </ul>
+ */
+public class CloudDeviceApiTerminalIT extends BaseIntegrationTest {
+
+  @Disabled("Enable when you want to test with the Terminal")
+  @Test
+  public void sendSync() throws Exception {
+
+    CloudDeviceApi cloudDeviceApi = new CloudDeviceApi(getClient());
+
+    CloudDeviceApiRequest cloudDeviceApiRequest =
+        createCloudDeviceAPIPaymentRequest(getTerminalDeviceId());
+
+    var response =
+        cloudDeviceApi.sync(getMerchantAccount(), getTerminalDeviceId(), cloudDeviceApiRequest);
+
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(response.getSaleToPOIResponse());
+    Assertions.assertEquals(getTerminalDeviceId(), response.getSaleToPOIResponse().getMessageHeader().getPOIID());
+  }
+
+  @Disabled("Enable when you want to test with the Terminal")
+  @Test
+  public void sendAsync() throws Exception {
+
+    CloudDeviceApi cloudDeviceApi = new CloudDeviceApi(getClient());
+
+    CloudDeviceApiRequest cloudDeviceApiRequest =
+        createCloudDeviceAPIPaymentRequest(getTerminalDeviceId());
+
+    var response =
+        cloudDeviceApi.async(getMerchantAccount(), getTerminalDeviceId(), cloudDeviceApiRequest);
+
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals("ok", response.getResult());
+  }
+
+  @Disabled("Enable when you want to test with the Terminal")
+  @Test
+  public void sendEncryptedSync() throws Exception {
+
+    CloudDeviceApiRequest cloudDeviceApiRequest =
+        createCloudDeviceAPIPaymentRequest(getTerminalDeviceId());
+
+    EncryptionCredentialDetails encryptionCredentialDetails =
+        new EncryptionCredentialDetails()
+            .adyenCryptoVersion(1)
+            .keyIdentifier(getTerminalDeviceKeyIdentifier())
+            .keyVersion(1)
+            .passphrase(getTerminalDevicePassphrase());
+
+    EncryptedCloudDeviceApi encryptedCloudDeviceApi =
+        new EncryptedCloudDeviceApi(getClient(), encryptionCredentialDetails);
+
+    var response =
+        encryptedCloudDeviceApi.sync(
+            getMerchantAccount(), getTerminalDeviceId(), cloudDeviceApiRequest);
+
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(response.getSaleToPOIResponse());
+    Assertions.assertEquals(getTerminalDeviceId(), response.getSaleToPOIResponse().getMessageHeader().getPOIID());
+  }
+
+  @Disabled("Enable when you want to test with the Terminal")
+  @Test
+  public void getConnectedDevices() throws Exception {
+
+    CloudDeviceApi cloudDeviceApi = new CloudDeviceApi(getClient());
+
+    var response = cloudDeviceApi.getConnectedDevices(getMerchantAccount());
+
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(response.getUniqueDeviceIds());
+    Assertions.assertTrue(response.getUniqueDeviceIds().contains(getTerminalDeviceId()));
+  }
+
+  @Disabled("Enable when you want to test with the Terminal")
+  @Test
+  public void sendEncryptedAsync() throws Exception {
+
+    CloudDeviceApiRequest cloudDeviceApiRequest =
+        createCloudDeviceAPIPaymentRequest(getTerminalDeviceId());
+
+    EncryptionCredentialDetails encryptionCredentialDetails =
+        new EncryptionCredentialDetails()
+            .adyenCryptoVersion(1)
+            .keyIdentifier(getTerminalDeviceKeyIdentifier())
+            .keyVersion(1)
+            .passphrase(getTerminalDevicePassphrase());
+
+    EncryptedCloudDeviceApi encryptedCloudDeviceApi =
+        new EncryptedCloudDeviceApi(getClient(), encryptionCredentialDetails);
+
+    var response =
+        encryptedCloudDeviceApi.async(
+            getMerchantAccount(), getTerminalDeviceId(), cloudDeviceApiRequest);
+
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals("ok", response.getResult());
+  }
+
+  protected CloudDeviceApiRequest createCloudDeviceAPIPaymentRequest(String deviceId) {
+    SaleToPOIRequest saleToPOIRequest = new SaleToPOIRequest();
+
+    var randomId = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 10);
+
+    MessageHeader messageHeader = new MessageHeader();
+    messageHeader.setProtocolVersion("3.0");
+    messageHeader.setMessageClass(MessageClass.SERVICE);
+    messageHeader.setMessageCategory(MessageCategory.PAYMENT);
+    messageHeader.setMessageType(MessageType.REQUEST);
+    messageHeader.setSaleID(randomId);
+    messageHeader.setServiceID(randomId);
+    messageHeader.setPOIID(deviceId);
+
+    saleToPOIRequest.setMessageHeader(messageHeader);
+
+    PaymentRequest paymentRequest = new PaymentRequest();
+
+    SaleData saleData = new SaleData();
+    TransactionIDType transactionIdentification = new TransactionIDType();
+    transactionIdentification.setTransactionID(randomId);
+    OffsetDateTime timestamp = OffsetDateTime.now(ZoneOffset.UTC);
+    transactionIdentification.setTimeStamp(timestamp);
+    saleData.setSaleTransactionID(transactionIdentification);
+
+    PaymentTransaction paymentTransaction = new PaymentTransaction();
+    AmountsReq amountsReq = new AmountsReq();
+    amountsReq.setCurrency("EUR");
+    amountsReq.setRequestedAmount(BigDecimal.TEN);
+    paymentTransaction.setAmountsReq(amountsReq);
+
+    paymentRequest.setSaleData(saleData);
+    paymentRequest.setPaymentTransaction(paymentTransaction);
+
+    saleToPOIRequest.setPaymentRequest(paymentRequest);
+
+    CloudDeviceApiRequest cloudDeviceApiRequest = new CloudDeviceApiRequest();
+    cloudDeviceApiRequest.setSaleToPOIRequest(saleToPOIRequest);
+
+    return cloudDeviceApiRequest;
+  }
+}

--- a/src/test/java/com/adyen/service/clouddevice/CloudDeviceApiTest.java
+++ b/src/test/java/com/adyen/service/clouddevice/CloudDeviceApiTest.java
@@ -11,6 +11,7 @@ import com.adyen.enums.Environment;
 import com.adyen.enums.Region;
 import com.adyen.model.clouddevice.*;
 import com.adyen.model.tapi.*;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -222,6 +223,66 @@ public class CloudDeviceApiTest extends BaseTest {
             null,
             ApiConstants.HttpMethod.GET,
             null);
+  }
+
+  @Test
+  public void cloudDeviceApiRequestSerialisesMessageHeader() throws Exception {
+    CloudDeviceApiRequest request = createCloudDeviceAPIPaymentRequest();
+
+    String json = request.toJson();
+    JsonNode root = JSON.getMapper().readTree(json);
+    JsonNode messageHeader = root.path("SaleToPOIRequest").path("MessageHeader");
+
+    Assertions.assertEquals("3.0", messageHeader.path("ProtocolVersion").asText());
+    Assertions.assertEquals("Service", messageHeader.path("MessageClass").asText());
+    Assertions.assertEquals("Payment", messageHeader.path("MessageCategory").asText());
+    Assertions.assertEquals("Request", messageHeader.path("MessageType").asText());
+    Assertions.assertEquals("001", messageHeader.path("SaleID").asText());
+    Assertions.assertEquals("001", messageHeader.path("ServiceID").asText());
+    Assertions.assertEquals("P400Plus-123456789", messageHeader.path("POIID").asText());
+  }
+
+  @Test
+  public void cloudDeviceApiRequestSerialisesPaymentRequest() throws Exception {
+    CloudDeviceApiRequest request = createCloudDeviceAPIPaymentRequest();
+
+    String json = request.toJson();
+    JsonNode root = JSON.getMapper().readTree(json);
+    JsonNode amountsReq =
+        root.path("SaleToPOIRequest")
+            .path("PaymentRequest")
+            .path("PaymentTransaction")
+            .path("AmountsReq");
+
+    Assertions.assertEquals("EUR", amountsReq.path("Currency").asText());
+    Assertions.assertEquals(
+        BigDecimal.ONE, amountsReq.path("RequestedAmount").decimalValue().stripTrailingZeros());
+  }
+
+  @Test
+  public void cloudDeviceApiRequestSerialisesTransactionId() throws Exception {
+    CloudDeviceApiRequest request = createCloudDeviceAPIPaymentRequest();
+
+    String json = request.toJson();
+    JsonNode root = JSON.getMapper().readTree(json);
+    JsonNode saleTransactionID =
+        root.path("SaleToPOIRequest")
+            .path("PaymentRequest")
+            .path("SaleData")
+            .path("SaleTransactionID");
+
+    Assertions.assertEquals("001", saleTransactionID.path("TransactionID").asText());
+    Assertions.assertFalse(saleTransactionID.path("TimeStamp").isMissingNode());
+  }
+
+  @Test
+  public void cloudDeviceApiRequestRoundTrip() throws Exception {
+    CloudDeviceApiRequest original = createCloudDeviceAPIPaymentRequest();
+
+    String json = original.toJson();
+    CloudDeviceApiRequest deserialised = CloudDeviceApiRequest.fromJson(json);
+
+    Assertions.assertEquals(original, deserialised);
   }
 
   protected CloudDeviceApiRequest createCloudDeviceAPIPaymentRequest() {

--- a/src/test/java/com/adyen/service/clouddevice/EncryptedCloudDeviceApiTest.java
+++ b/src/test/java/com/adyen/service/clouddevice/EncryptedCloudDeviceApiTest.java
@@ -149,6 +149,44 @@ public class EncryptedCloudDeviceApiTest extends BaseTest {
   }
 
   @Test
+  public void syncUnencryptedErrorResponse() throws Exception {
+    Client client = createMockClientFromFile("mocks/clouddevice/payment-sync-error.json");
+    EncryptedCloudDeviceApi api = new EncryptedCloudDeviceApi(client, DEFAULT_CREDENTIALS);
+
+    var response =
+        api.sync("TestMerchantAccount", "MX915-284251016", createCloudDeviceAPIPaymentRequest());
+
+    Assertions.assertNotNull(response);
+    Assertions.assertNotNull(response.getSaleToPOIResponse());
+    Assertions.assertNotNull(response.getSaleToPOIResponse().getPaymentResponse());
+    Assertions.assertEquals(
+        "Failure",
+        response.getSaleToPOIResponse().getPaymentResponse().getResponse().getResult().getValue());
+    Assertions.assertEquals(
+        "UnreachableHost",
+        response
+            .getSaleToPOIResponse()
+            .getPaymentResponse()
+            .getResponse()
+            .getErrorCondition()
+            .getValue());
+  }
+
+  @Test
+  public void asyncUnencryptedErrorResponse() throws Exception {
+    Client client = createMockClientFromFile("mocks/clouddevice/payment-async-error.json");
+    EncryptedCloudDeviceApi api = new EncryptedCloudDeviceApi(client, DEFAULT_CREDENTIALS);
+
+    var response =
+        api.async("TestMerchantAccount", "MX915-284251016", createCloudDeviceAPIPaymentRequest());
+
+    Assertions.assertNotNull(response);
+    Assertions.assertNull(response.getResult());
+    Assertions.assertNotNull(response.getSaleToPOIRequest());
+    Assertions.assertNotNull(response.getSaleToPOIRequest().getMessageHeader());
+  }
+
+  @Test
   public void decryptNotificationInvalidPayload() throws Exception {
     Client client = createMockClientFromResponse("");
     EncryptedCloudDeviceApi api =

--- a/src/test/java/com/adyen/service/clouddevice/e2e-testing.md
+++ b/src/test/java/com/adyen/service/clouddevice/e2e-testing.md
@@ -1,0 +1,44 @@
+# E2E Testing with a POS Terminal
+
+`CloudDeviceApiTerminalIT` contains end-to-end tests that send real requests to a Cloud Device API terminal. All tests are disabled by default and must be enabled manually before running.
+
+## Prerequisites
+
+- A physical POS terminal connected and switched on
+- An Adyen test account with the Cloud Device API enabled
+- Terminal encryption credentials (key identifier and passphrase) for testing the encryption of payloads
+
+## Configuration
+
+Create `src/test/resources/config.properties` (excluded from version control):
+
+```properties
+ADYEN_API_KEY=
+ADYEN_MERCHANT_ACCOUNT=MyMerchantAccount
+ADYEN_TERMINAL_DEVICE_ID=V400m-1234567890
+ADYEN_TERMINAL_DEVICE_KEY_IDENTIFIER=
+ADYEN_TERMINAL_DEVICE_PASSPHRASE=
+```
+
+Alternatively, export the same keys as environment variables.
+
+## Running a test
+
+1. Remove the `@Disabled` annotation from the test you want to run.
+2. Execute it individually:
+   ```bash
+   mvn test -Dtest=CloudDeviceApiTerminalIT#sendSync
+   ```
+3. Re-add the `@Disabled` annotation when done.
+
+> Run one test at a time. The terminal can only handle one active request at a time.
+
+## Available tests
+
+| Test | Description |
+|---|---|
+| `sendSync` | Sends a payment request and waits for the terminal response |
+| `sendAsync` | Sends a payment request asynchronously (terminal processes in background) |
+| `sendEncryptedSync` | Same as `sendSync` with end-to-end NexoSEC encryption |
+| `sendEncryptedAsync` | Same as `sendAsync` with end-to-end NexoSEC encryption |
+| `getConnectedDevices` | Lists devices connected to the merchant account |

--- a/src/test/resources/mocks/clouddevice/payment-sync-error.json
+++ b/src/test/resources/mocks/clouddevice/payment-sync-error.json
@@ -1,0 +1,20 @@
+{
+  "SaleToPOIResponse": {
+    "MessageHeader": {
+      "ProtocolVersion": "3.0",
+      "SaleID": "001",
+      "MessageClass": "Service",
+      "MessageCategory": "Payment",
+      "ServiceID": "001",
+      "POIID": "MX915-284251016",
+      "MessageType": "Response"
+    },
+    "PaymentResponse": {
+      "Response": {
+        "Result": "Failure",
+        "ErrorCondition": "UnreachableHost",
+        "AdditionalResponse": "message=Terminal+is+not+reachable"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds end-to-end integration tests for the Cloud Device API (sync, async, encrypted variants):
- add `CloudDeviceApiTerminalIT` for sending requests to a terminal
- add `e2e-testing.md` documenting how to configure and run the terminal tests
- fix `EncryptedCloudDeviceApi.async()` to handle unencrypted error responses (e.g. terminal unreachable) the same way `sync()` does
