### PR TITLE
fix: use String.replace() instead of replaceFirst() in createBaseURL

### DIFF
--- a/src/main/java/com/adyen/Service.java
+++ b/src/main/java/com/adyen/Service.java
@@ -99,7 +99,7 @@ public class Service {
         throw new IllegalArgumentException("please provide a live url prefix in the client");
       }
       url =
-          url.replaceFirst(
+          url.replace(
               "https://pal-test.adyen.com/pal/servlet/",
               "https://"
                   + config.getLiveEndpointUrlPrefix()
@@ -113,14 +113,14 @@ public class Service {
       if (url.contains("/possdk/")) {
         // Custom handling of POS Mobile API url
         url =
-            url.replaceFirst(
+            url.replace(
                 "https://checkout-test.adyen.com/",
                 "https://"
                     + config.getLiveEndpointUrlPrefix()
                     + "-checkout-live.adyenpayments.com/");
       } else {
         url =
-            url.replaceFirst(
+            url.replace(
                 "https://checkout-test.adyen.com/",
                 "https://"
                     + config.getLiveEndpointUrlPrefix()
@@ -132,11 +132,11 @@ public class Service {
       if (config.getTerminalApiRegion() == null
           || config.getTerminalApiRegion().equals(Region.EU)) {
         url =
-            url.replaceFirst(
+            url.replace(
                 "https://device-api-test.adyen.com", "https://device-api-live.adyen.com");
       } else {
         url =
-            url.replaceFirst(
+            url.replace(
                 "https://device-api-test.adyen.com",
                 String.format(
                     "https://device-api-live-%s.adyen.com",

--- a/src/main/java/com/adyen/Service.java
+++ b/src/main/java/com/adyen/Service.java
@@ -91,7 +91,7 @@ public class Service {
     }
 
     if (url.contains("/authe/")) {
-      return url.replaceFirst("https://test.adyen.com/", "https://authe-live.adyen.com/");
+      return url.replace("https://test.adyen.com/", "https://authe-live.adyen.com/");
     }
 
     if (url.contains("pal-")) {

--- a/src/main/java/com/adyen/Service.java
+++ b/src/main/java/com/adyen/Service.java
@@ -131,9 +131,7 @@ public class Service {
     if (url.contains("device-api-")) {
       if (config.getTerminalApiRegion() == null
           || config.getTerminalApiRegion().equals(Region.EU)) {
-        url =
-            url.replace(
-                "https://device-api-test.adyen.com", "https://device-api-live.adyen.com");
+        url = url.replace("https://device-api-test.adyen.com", "https://device-api-live.adyen.com");
       } else {
         url =
             url.replace(

--- a/src/test/java/com/adyen/ServiceTest.java
+++ b/src/test/java/com/adyen/ServiceTest.java
@@ -61,14 +61,16 @@ public class ServiceTest extends BaseTest {
   @Test
   public void testLivePalUrlOnlyMatchesLiteralDots() {
     config.setLiveEndpointUrlPrefix("123456789-company");
-    // A URL where dots are replaced with other characters should NOT be transformed
-    // by the pal- block. String.replace() does exact literal matching, so a URL that
-    // looks like a pal URL but has non-dot separators passes through untouched.
-    String urlWithNonDots = "https://pal-devXadyenYcom/pal/servlet/v52/initiate";
+    // This URL matches pal-test.adyen.com structurally but has non-dot separators.
+    // The old replaceFirst() would have incorrectly matched it (dots as wildcards).
+    // String.replace() does exact literal matching so the pal- block leaves it unchanged.
+    // The final fallback still converts -test to -live as expected.
+    String urlWithNonDots = "https://pal-testXadyenYcom/pal/servlet/v52/initiate";
+    String expectedUrl = "https://pal-liveXadyenYcom/pal/servlet/v52/initiate";
 
     String actualUrl = service.createBaseURL(urlWithNonDots);
 
-    assertEquals(urlWithNonDots, actualUrl);
+    assertEquals(expectedUrl, actualUrl);
   }
 
   @Test

--- a/src/test/java/com/adyen/ServiceTest.java
+++ b/src/test/java/com/adyen/ServiceTest.java
@@ -59,6 +59,19 @@ public class ServiceTest extends BaseTest {
   }
 
   @Test
+  public void testLivePalUrlOnlyMatchesLiteralDots() {
+    config.setLiveEndpointUrlPrefix("123456789-company");
+    // A URL where dots are replaced with other characters should NOT be transformed
+    // by the pal- block. String.replace() does exact literal matching, so a URL that
+    // looks like a pal URL but has non-dot separators passes through untouched.
+    String urlWithNonDots = "https://pal-devXadyenYcom/pal/servlet/v52/initiate";
+
+    String actualUrl = service.createBaseURL(urlWithNonDots);
+
+    assertEquals(urlWithNonDots, actualUrl);
+  }
+
+  @Test
   public void testLivePalUrlWithoutPrefix() {
     String testUrl = "https://pal-test.adyen.com/pal/servlet/v52/initiate";
 


### PR DESCRIPTION
Fixes #1838

### What
`createBaseURL` in `Service.java` used `String.replaceFirst()` to swap test URLs 
for live URLs. Since `replaceFirst()` accepts a regex pattern, dots in the URL 
strings (e.g. `pal-test.adyen.com`) were treated as wildcards — matching any 
character instead of a literal dot.

### Fix
Replaced the affected `replaceFirst()` calls with `String.replace()`, which does 
plain literal string matching. No regex involved, no wildcard risk.

The following blocks were updated:
- `pal-` block
- `checkout-` block (both the `/possdk/` branch and the standard branch)
- `device-api-` block (both EU and non-EU branches)

The two calls without dots (`-live` → `-test` and `-test` → `-live`) were 
intentionally left as `replaceFirst()` since they are not affected by this issue.

### Test
Added `testLivePalUrlOnlyMatchesLiteralDots()` to `ServiceTest.java` to verify 
that a URL resembling a pal endpoint but without literal dots is not incorrectly 
transformed by the `pal-` block.