### PR TITLE
chore: add spotless check on PRs to prevent formatting drift

### DIFF
--- a/.github/workflows/javaci.yml
+++ b/.github/workflows/javaci.yml
@@ -35,6 +35,8 @@ jobs:
             ${{ runner.os }}-m2-
       - name: Check code style
         run: mvn -B checkstyle:check --no-transfer-progress
+      - name: Check Java Formatting
+        run: mvn spotless:check --no-transfer-progress
 
   java-test:
     name: Build and Test


### PR DESCRIPTION
**Description**

This PR introduces a spotless:check run on Java CI, to prevent manually pushing code with formatting drifts