### PR TITLE
Fix README: unwrap Optional before passing to validateHMAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,17 +256,18 @@ NotificationRequest notificationRequest = webhookHandler.handleNotificationJson(
 var notificationRequestItem = notificationRequest.getNotificationItems().stream().findFirst();
 
 if (notificationRequestItem.isPresent()) {
+    var item = notificationRequestItem.get();
     // validate the HMAC signature
-    if ( hmacValidator.validateHMAC(notificationRequestItem.get(), hmacKey) ) {
+    if (hmacValidator.validateHMAC(item, hmacKey)) {
       // Process the notification based on the eventCode
       log.info("Received webhook with event {} : \n" +
         "Merchant Reference: {}\n" +
         "Alias : {}\n" +
         "PSP reference : {}", 
-        notificationRequestItem.getEventCode(), 
-        notificationRequestItem.getMerchantReference(),
-        notificationRequestItem.getAdditionalData().get("alias"),
-        notificationRequestItem.getPspReference());
+        item.getEventCode(), 
+        item.getMerchantReference(),
+        item.getAdditionalData().get("alias"),
+        item.getPspReference());
     } else {
       // Non valid NotificationRequest
 	  throw new RuntimeException("Invalid HMAC signature");

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ var notificationRequestItem = notificationRequest.getNotificationItems().stream(
 
 if (notificationRequestItem.isPresent()) {
     // validate the HMAC signature
-    if ( hmacValidator.validateHMAC(notificationRequestItem, hmacKey) ) {
+    if ( hmacValidator.validateHMAC(notificationRequestItem.get(), hmacKey) ) {
       // Process the notification based on the eventCode
       log.info("Received webhook with event {} : \n" +
         "Merchant Reference: {}\n" +


### PR DESCRIPTION
## Description
The notification webhook example in README.md was passing an `Optional<NotificationRequestItem>` directly to `hmacValidator.validateHMAC()`, which expects a `NotificationRequestItem`. Fixed by calling `.get()` on the Optional (inside the already-guarded `isPresent()` check).

## Tested scenarios
N/A — documentation-only fix.

## Fixed issue
Fix #1957 