### PR TITLE
do-not-merge: investigating behavior of paymentMethods/

### DIFF
--- a/src/test/java/com/adyen/CheckoutTest.java
+++ b/src/test/java/com/adyen/CheckoutTest.java
@@ -173,6 +173,19 @@ public class CheckoutTest extends BaseTest {
     PaymentMethodsResponse paymentMethodsResponse = checkout.paymentMethods(paymentMethodsRequest);
     assertEquals(1, paymentMethodsResponse.getPaymentMethods().size());
     assertEquals("klarna", paymentMethodsResponse.getPaymentMethods().get(0).getType());
+
+    assertEquals(2, paymentMethodsResponse.getStoredPaymentMethods().size());
+    StoredPaymentMethod storedMethod = paymentMethodsResponse.getStoredPaymentMethods().get(0);
+    assertEquals("visa", storedMethod.getBrand());
+    assertEquals("STORED_PAYMENT_METHOD_ID", storedMethod.getId());
+    assertEquals("1111", storedMethod.getLastFour());
+    assertEquals("scheme", storedMethod.getType());
+
+    StoredPaymentMethod other = paymentMethodsResponse.getStoredPaymentMethods().get(1);
+    assertNull(other.getBrand()); // there is no card brand
+    assertNull(other.getLastFour()); // there is no last four digits
+    assertEquals("CASHAPP_STORED_PAYMENT_METHOD_ID", other.getId());
+    assertEquals("cashapp", other.getType());
   }
 
   /** Should make paymentLink call */

--- a/src/test/resources/mocks/checkout/paymentMethodsResponse.json
+++ b/src/test/resources/mocks/checkout/paymentMethodsResponse.json
@@ -4,5 +4,26 @@
       "name": "Pay later with Klarna.",
       "type": "klarna"
     }
+  ],
+  "storedPaymentMethods": [
+    {
+      "brand": "visa",
+      "expiryMonth": "03",
+      "expiryYear": "2030",
+      "holderName": "John Doe",
+      "id": "STORED_PAYMENT_METHOD_ID",
+      "lastFour": "1111",
+      "name": "VISA",
+      "type": "scheme",
+      "supportedShopperInteractions": ["Ecommerce", "ContAuth"]
+    },
+    {
+      "cashtag": "$CASHTAG_C_TOKEN ---this is an unknown field and will be silently ignored",
+      "id": "CASHAPP_STORED_PAYMENT_METHOD_ID",
+      "name": "Cash App Pay",
+      "supportedRecurringProcessingModels": ["CardOnFile", "Subscription", "UnscheduledCardOnFile"],
+      "supportedShopperInteractions": ["Ecommerce", "ContAuth"],
+      "type": "cashapp"
+    }
   ]
 }


### PR DESCRIPTION
This commit has a mock response with custom fields (cashapp tag) to test the deserialization of storedPaymentMethods