### PR TITLE
Exclude generated OpenAPI models from SonarCloud coverage and duplication checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <sonar.organization>adyen</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.exclusions>**/com/adyen/model/*/**</sonar.coverage.exclusions>
 
         <!-- Dependency Versions -->
         <!-- Compile -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <sonar.coverage.exclusions>**/com/adyen/model/*/**</sonar.coverage.exclusions>
+        <sonar.cpd.exclusions>**/com/adyen/model/*/**</sonar.cpd.exclusions>
 
         <!-- Dependency Versions -->
         <!-- Compile -->


### PR DESCRIPTION
## Context
The generated data model classes under `com/adyen/model/<api>/**` (POJOs, getters/setters, `equals`/`hashCode`/`toString`, `isSet*` flags, `getExplicitNulls`, `toJson`/`fromJson`, and the generated per-package `JSON.java` mapper config) are produced by OpenAPI Generator via [adyen-sdk-automation](https://github.com/Adyen/adyen-sdk-automation) and are not hand-maintained. They were skewing two SonarCloud metrics:

1. **Coverage** — diluting the coverage % with untested boilerplate.
2. **Duplication (CPD)** — the repetitive generated template triggers huge numbers of duplicated-block warnings. Representative CI run: [job 86166267497](https://github.com/Adyen/adyen-java-api-library/actions/runs/29031747289/job/86166267497?pr=2002) logged hundreds of *'Too many duplication references ... Keep only the first 100 references'* warnings, all within `com/adyen/model/**`.

Both are generation artifacts, not real maintenance/test-gap signals, and they drown out genuine signal from hand-written code.

## Change
Add two properties to `pom.xml`, using the same glob for consistency:

```xml
<sonar.coverage.exclusions>**/com/adyen/model/*/**</sonar.coverage.exclusions>
<sonar.cpd.exclusions>**/com/adyen/model/*/**</sonar.cpd.exclusions>
```

These only affect the coverage and duplication **metrics/quality gates**; Sonar still analyzes the excluded files for bugs, vulnerabilities, and code smells.

## Why this glob
- Matches files at least one directory below `com/adyen/model/`, i.e. the generated per-API packages (`model/checkout/**`, `model/management/**`, ...).
- Does **not** match the top-level `com/adyen/model/*.java` files, so the hand-written `ApiError.java` and `RequestOptions.java` remain in scope (the generated `InvalidField.java` also stays in scope — a single trivial file, not worth a more complex exclusion pattern).
- Path-based and therefore self-maintaining: any new generated API package added under `model/` is automatically excluded going forward.

## What stays fully in scope
- `com/adyen/serializer/**` (`ByteArraySerializer`, `DateSerializer`, custom Jackson (de)serializers)
- `com/adyen/terminal/serialization/**` (XML/Base64 type adapters)
- `com/adyen/service/**` (generated services intentionally left in scope for now — no duplication warnings were observed there)
- All other hand-written library code (`Client`, `Service`, `Config`, `httpclient`, `util`, `security`, `notification`, builders)

## Verification
- `mvn validate` passes.
- `mvn help:evaluate -Dexpression=sonar.coverage.exclusions -DforceStdout` and `-Dexpression=sonar.cpd.exclusions` both resolve to `**/com/adyen/model/*/**`.
- Confirmed via CI log that all captured duplication warnings originate from `com/adyen/model/**` (251/251 in the sampled run), none from `service/` or hand-written packages.
- Follow-up: confirm on the next SonarCloud run that coverage % and duplication % reflect only non-generated code.