### PR TITLE
Adding an import for java.util.List

### DIFF
--- a/templates-v7/libraries/jersey3/api.mustache
+++ b/templates-v7/libraries/jersey3/api.mustache
@@ -13,6 +13,7 @@ import com.adyen.service.resource.Resource;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 {{#operations}}
 public class {{classname}} extends Service {


### PR DESCRIPTION
**Description**
Fixed issue `symbol not found` for `List`.
Adds an unconditional import of java.util.List to the Jersey 3 API mustache template.


**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
