### PR TITLE
Fixing template to support javadocs generation for arrays and maps

### DIFF
--- a/templates-v7/libraries/jersey3/api_summary.mustache
+++ b/templates-v7/libraries/jersey3/api_summary.mustache
@@ -2,17 +2,17 @@
     * {{summary}}
     *
 {{#pathParams}}
-    * @param {{paramName}} {@link {{dataType}} } {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/isContainer}}{{/required}}
+    * @param {{paramName}} {{#isContainer}}{@code {{{dataType}}} }{{/isContainer}}{{^isContainer}}{@link {{dataType}} }{{/isContainer}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/isContainer}}{{/required}}
 {{/pathParams}}
 {{#bodyParams}}
-    * @param {{paramName}} {@link {{dataType}} } {{description}} (required)
+    * @param {{paramName}} {{#isContainer}}{@code {{{dataType}}} }{{/isContainer}}{{^isContainer}}{@link {{dataType}} }{{/isContainer}} {{description}} (required)
 {{/bodyParams}}
 {{#queryParams}}
-    * @param {{paramName}} {@link {{dataType}} } Query: {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/isContainer}}{{/required}}
+    * @param {{paramName}} {{#isContainer}}{@code {{{dataType}}} }{{/isContainer}}{{^isContainer}}{@link {{dataType}} }{{/isContainer}} Query: {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/isContainer}}{{/required}}
 {{/queryParams}}
     * @param requestOptions {@link RequestOptions } Object to store additional HTTP headers such as idempotency-keys (optional)
 {{#returnType}}
-    * @return {@link {{.}} }
+    * @return {{#returnContainer}}{@code {{{returnType}}} }{{/returnContainer}}{{^returnContainer}}{@link {{.}} }{{/returnContainer}}
 {{/returnType}}
     * @throws ApiException if fails to make API call
 {{#isDeprecated}}


### PR DESCRIPTION
**Description**

 The Javadoc build fails with error: 
   `unexpected text when a generated API method  has a parameter or return type that is a  generic container (e.g. 
   List<ExecutionResult>)`.
 This PR fixes the OpenAPI Mustache template so those types render as valid Javadoc.

 The api_summary.mustache template embedded the parameter/return type inside a {@link}  tag using double-brace interpolation ({@link  {{dataType}} }). Mustache HTML-escapes {{  }}, so a generic type like List<ExecutionResult> was emitted as:
```
  @param results {@link
     List&lt;ExecutionResult&gt; } ...
```
   This never surfaced before because the   {@link <type>} pattern is only used for  operation parameters/return types (model  fields use the property name, not the type), and no prior operation had a  container-typed parameter or return.

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
 For container types (isContainer), render the type with  {@code} (which safely handles angle brackets and needs no reference resolution) using  unescaped triple-brace interpolation. 
   Non-container types are unchanged and still  use clickable {@link}.

   •  List<ExecutionResult> → {@code List<ExecutionResult> } (valid, renders the full generic type)
   •  String, Integer, model classes → still  {@link ... } (clickable, unchanged)

   Applied to path params, body params, query  params, and the @return tag.
