### PR TITLE
Fix - pathParam conversion from enum to string

### DIFF
--- a/templates-v7/libraries/jersey3/api.mustache
+++ b/templates-v7/libraries/jersey3/api.mustache
@@ -64,7 +64,7 @@ public class {{classname}} extends Service {
         if ({{{paramName}}} == null) {
             throw new IllegalArgumentException("Please provide the {{{paramName}}} path parameter");
         }
-        pathParams.put("{{baseName}}", {{{paramName}}});
+        pathParams.put("{{baseName}}", {{{paramName}}}{{^isString}}.toString(){{/isString}});
         {{/pathParams}}
 
         {{/hasPathParams}}


### PR DESCRIPTION
**Description**
Fix template to convert non-String path parameters (e.g. enums) with .toString(), preventing compile errors like the new CampaignStatusTransition status path param  in DonationCampaignsApi.

**Error**
```
Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.15.0:compile (default-compile) on project adyen-java-api-library: Compilation failure
Error:  /home/runner/work/adyen-java-api-library/adyen-java-api-library/src/main/java/com/adyen/service/management/DonationCampaignsApi.java:[403,30] incompatible types: com.adyen.model.management.CampaignStatusTransition cannot be converted to java.lang.String
```

Git hub pipeline  - https://github.com/Adyen/adyen-java-api-library/actions/runs/29820136294/job/88600760813?pr=2004


