### PR TITLE
Fix NoPluginFoundForPrefixException for sonar

### DIFF
--- a/.github/workflows/javaci.yml
+++ b/.github/workflows/javaci.yml
@@ -97,5 +97,5 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >
-          mvn -B --no-transfer-progress clean test jacoco:report sonar:sonar
+          mvn -B --no-transfer-progress clean test jacoco:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
           -Dsonar.projectKey=Adyen_adyen-java-api-library

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,5 +38,5 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >
-          mvn -B clean test jacoco:report sonar:sonar
+          mvn -B clean test jacoco:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
           -Dsonar.projectKey=Adyen_adyen-java-api-library


### PR DESCRIPTION
**Description**

   CI's SonarCloud step started failing with No plugin found for prefix 'sonar'. 

   This replaces `sonar:sonar` with the supported, fully-qualified goal `org.sonarsource.scanner.maven:sonar-maven-plugin:sonar` in both workflows (javaci.yml, sonarcloud.yml). The version is ,intentionally omitted so Maven resolves the latest scanner release automatically — no manual version bumps required.


**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
