### PR TITLE
Inject Pooling Connection Manager

### DIFF
--- a/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
+++ b/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
@@ -93,14 +93,29 @@ public class AdyenHttpClient implements ClientInterface {
 
   private static final String CHARSET = "UTF-8";
   private Proxy proxy;
-  private PoolingHttpClientConnectionManager sharedConnectionManager;
+  private final PoolingHttpClientConnectionManager sharedConnectionManager;
   private volatile CloseableHttpClient sharedHttpClient;
   private final Object lock = new Object();
 
   public AdyenHttpClient() {
-    super();
+    this(null);
   }
 
+  /**
+   * Creates an AdyenHttpClient with a shared connection manager.
+   * <p>
+   * <b>Note:</b> When using a shared connection manager:
+   * <ul>
+   *   <li>Any custom {@link SSLContext} or {@link HostnameVerifier} configured in {@link Config}
+   *       will be ignored, as the connection manager's own socket factory registry is used.</li>
+   *   <li>Connection-level configurations (such as {@code connectTimeout} and {@code socketTimeout})
+   *       must be pre-configured on the shared connection manager, as the timeouts from {@link Config}
+   *       will only be applied at the request level (via {@link RequestConfig}).</li>
+   * </ul>
+   * </p>
+   * 
+   * @param connectionManager the shared connection manager to use
+   */
   public AdyenHttpClient(PoolingHttpClientConnectionManager connectionManager) {
     this.sharedConnectionManager = connectionManager;
   }

--- a/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
+++ b/src/main/java/com/adyen/httpclient/AdyenHttpClient.java
@@ -56,7 +56,9 @@ import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.core5.http.HttpHost;
@@ -91,8 +93,17 @@ public class AdyenHttpClient implements ClientInterface {
 
   private static final String CHARSET = "UTF-8";
   private Proxy proxy;
+  private PoolingHttpClientConnectionManager sharedConnectionManager;
   private volatile CloseableHttpClient sharedHttpClient;
   private final Object lock = new Object();
+
+  public AdyenHttpClient() {
+    super();
+  }
+
+  public AdyenHttpClient(PoolingHttpClientConnectionManager connectionManager) {
+    this.sharedConnectionManager = connectionManager;
+  }
 
   /**
    * Returns the proxy configured for this HTTP client.
@@ -372,7 +383,12 @@ public class AdyenHttpClient implements ClientInterface {
                 config.getConnectionRequestTimeoutMillis(), TimeUnit.MILLISECONDS)
             .setDefaultKeepAlive(config.getDefaultKeepAliveMillis(), TimeUnit.MILLISECONDS)
             .build();
-    ConnectionConfig connectionConfig =
+    
+    HttpClientBuilder clientBuilder = HttpClients.custom();
+    if (sharedConnectionManager != null) {
+      clientBuilder = clientBuilder.setConnectionManager(sharedConnectionManager).setConnectionManagerShared(true);
+    } else {
+      ConnectionConfig connectionConfig =
         ConnectionConfig.custom()
             .setConnectTimeout(config.getConnectionTimeoutMillis(), TimeUnit.MILLISECONDS)
             // socketTimeout acts as an OS-level safety net for stalled reads;
@@ -381,12 +397,14 @@ public class AdyenHttpClient implements ClientInterface {
             // fires first.
             .setSocketTimeout(config.getReadTimeoutMillis(), TimeUnit.MILLISECONDS)
             .build();
-    return HttpClients.custom()
-        .setConnectionManager(
+      clientBuilder = clientBuilder.setConnectionManager(
             PoolingHttpClientConnectionManagerBuilder.create()
                 .setSSLSocketFactory(socketFactory)
                 .setDefaultConnectionConfig(connectionConfig)
-                .build())
+                .build());
+    }
+
+    return clientBuilder
         .setDefaultRequestConfig(defaultRequestConfig)
         .setRedirectStrategy(new AdyenCustomRedirectStrategy())
         .build();

--- a/src/test/java/com/adyen/httpclient/ClientTest.java
+++ b/src/test/java/com/adyen/httpclient/ClientTest.java
@@ -1,6 +1,9 @@
 package com.adyen.httpclient;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.adyen.BaseTest;
 import com.adyen.Client;
@@ -17,6 +20,7 @@ import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.config.Configurable;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.core5.http.Header;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -175,6 +179,39 @@ public class ClientTest extends BaseTest {
           config.getConnectionRequestTimeoutMillis(),
           defaultConfig.getConnectionRequestTimeout().toMilliseconds());
     }
+  }
+
+  @Test
+  public void testInjectedConnectionManagerAppliesDefaultRequestConfig() throws Exception {
+    PoolingHttpClientConnectionManager connectionManager =
+        mock(PoolingHttpClientConnectionManager.class);
+    Config config = new Config();
+    config.setReadTimeoutMillis(15000);
+    config.setConnectionRequestTimeoutMillis(30000);
+    config.setDefaultKeepAliveMillis(40000);
+
+    try (AdyenHttpClient adyenHttpClient = new AdyenHttpClient(connectionManager);
+      CloseableHttpClient httpClient = adyenHttpClient.createCloseableHttpClient(config)) {
+      assertInstanceOf(Configurable.class, httpClient);
+      RequestConfig defaultConfig = ((Configurable) httpClient).getConfig();
+      assertNotNull(defaultConfig);
+      assertEquals(15000, defaultConfig.getResponseTimeout().toMilliseconds());
+      assertEquals(30000, defaultConfig.getConnectionRequestTimeout().toMilliseconds());
+    }
+  }
+
+  @Test
+  public void testClosingHttpClientDoesNotCloseInjectedConnectionManager() throws Exception {
+    PoolingHttpClientConnectionManager connectionManager =
+        mock(PoolingHttpClientConnectionManager.class);
+
+    try (AdyenHttpClient adyenHttpClient = new AdyenHttpClient(connectionManager);
+        CloseableHttpClient httpClient = adyenHttpClient.createCloseableHttpClient(new Config())) {
+      assertNotNull(httpClient);
+      adyenHttpClient.close();
+    }
+
+    verify(connectionManager, never()).close();
   }
 
   @Test


### PR DESCRIPTION
In a microservices especially based on Spring Boot it is often useful to inject a shared `PoolingHttpClientConnectionManager` into all clients including the AdyenHttpClient. The benefits are 

* users of the Adyen Java Library can configure the pool size correctly based on their needs on the shared pooling connection manager before injecting it into the AdyenHttpClient and do not need to rely on the quite low default configuration (max 25 connections to different Adyen API domains and max 5 connections to the same Adyen API domain). The default with max 5 connections at the same time to one Adyen API domain can cause latency issues because of pool exhaustion under high load
* especially within Spring Boot applications users of the Adyen Java Library can inject a pooling connection manager that is connected to telemetry systems like micrometer making it possible to observe the load on the connection pool used by the AdyenHttpClient.

Created the no-args constructor for backward compatibility and added one for injecting a shared `PoolingHttpClientConnectionManager`. Adjusted the `createHttpClientWithSocketFactory` method to consider the shared connetction pool manager if necessary.