### PR TITLE
Make Swagger annotation dependencies optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,11 +307,13 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-v3-version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>


### PR DESCRIPTION
Fixes #2028.

Mark the Swagger v1 and v3 annotation artifacts as optional. The SDK still compiles with both dependencies, while applications that only use Adyen APIs no longer receive documentation metadata transitively or collide with Jakarta Swagger annotations. Consumers that reflect on Adyen model annotations can declare the relevant artifact explicitly.

Verification:

* `mvn test -DskipITs` — 617 tests, 0 failures/errors, 4 skips on JDK 26.
* A Spring Boot 4/Kotlin consumer compiles its Adyen payment, webhook, and terminal modules with both Swagger dependencies excluded.