### PR TITLE
Avoid Gson final-field mutation on modern JDKs

### DIFF
--- a/src/main/java/com/adyen/model/applicationinfo/ApplicationInfo.java
+++ b/src/main/java/com/adyen/model/applicationinfo/ApplicationInfo.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 
 public class ApplicationInfo {
   @SerializedName("adyenLibrary")
-  private final CommonField adyenLibrary;
+  private CommonField adyenLibrary;
 
   @SerializedName("adyenPaymentSource")
   private CommonField adyenPaymentSource = null;


### PR DESCRIPTION
Fixes #2030.

Make the Gson-serialized `adyenLibrary` field non-final. Gson already mutates this field during deserialization; on JDK 26 that reflective write emits a final-field mutation warning and is scheduled to require explicit opt-in under JEP 500.

The public API remains read-only because no setter is added, and the constructor continues to initialize the SDK name/version.

Verification:

* `mvn -Dtest=SaleToAcquirerDataSerializerTest test` — round trip passes and the final-field warning is gone.
* `mvn test -DskipITs` — 617 tests, 0 failures/errors, 4 skips on JDK 26.