### PR TITLE
Compile Java 11 artifacts with --release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,7 @@
     </developers>
     <properties>
         <!-- Project Settings -->
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <sonar.organization>adyen</sonar.organization>


### PR DESCRIPTION
Closes #2032.

Replace the separate Java source/target settings with `maven.compiler.release=11`. This preserves the Java 11 bytecode and language baseline while also preventing accidental linkage to JDK APIs introduced after Java 11.

Verification:

- `mvn clean test -DskipITs`
- compiler reports `[debug release 11]`
- the `system modules ... -source 11` warning is gone
- 617 tests pass, with 4 skipped