### PR TITLE
fix(release) removed the pull_request trigger for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,6 @@ on:
         type: boolean
         default: false
         description: "Publish Github release for the current version"
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
The current setup allows any member with write access to initiate a release by closing a pull request. Release processes should be explicit and deliberate. This PR removes this trigger.