### PR TITLE
Add Java CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # Adyen Java API Library
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.adyen/adyen-java-api-library)](https://central.sonatype.com/artifact/com.adyen/adyen-java-api-library/)
+[![Java CI](https://github.com/Adyen/adyen-java-api-library/actions/workflows/javaci.yml/badge.svg)](https://github.com/Adyen/adyen-java-api-library/actions/workflows/javaci.yml)
 
 This is the officially supported Java library for using Adyen's APIs.
 


### PR DESCRIPTION
## Description
Add the Java CI workflow badge to the README to make the workflow status visible.

## Tested scenarios
- Verified the badge references the existing `javaci.yml` workflow.
- Ran `git diff --check`.

## Fixed issue
N/A
