### PR TITLE
Add missing enum values for afterpaytouch_US and DEFFERED_DEBIT

### DIFF
--- a/src/main/java/com/adyen/model/checkout/AfterpayDetails.java
+++ b/src/main/java/com/adyen/model/checkout/AfterpayDetails.java
@@ -84,6 +84,8 @@ public class AfterpayDetails {
 
     AFTERPAYTOUCH(String.valueOf("afterpaytouch")),
 
+    AFTERPAYTOUCH_US(String.valueOf("afterpaytouch_US")),
+
     AFTERPAY_B2B(String.valueOf("afterpay_b2b")),
 
     CLEARPAY(String.valueOf("clearpay"));

--- a/src/main/java/com/adyen/model/checkout/CardDetails.java
+++ b/src/main/java/com/adyen/model/checkout/CardDetails.java
@@ -149,7 +149,9 @@ public class CardDetails {
 
     DEBIT(String.valueOf("debit")),
 
-    PREPAID(String.valueOf("prepaid"));
+    PREPAID(String.valueOf("prepaid")),
+
+    DEFFERED_DEBIT(String.valueOf("DEFFERED_DEBIT"));
 
     private static final Logger LOG = Logger.getLogger(FundingSourceEnum.class.getName());
 

--- a/src/main/java/com/adyen/model/checkout/CheckoutPaymentMethod.java
+++ b/src/main/java/com/adyen/model/checkout/CheckoutPaymentMethod.java
@@ -2041,6 +2041,7 @@ public class CheckoutPaymentMethod extends AbstractOpenApiSchema {
     mappings.put("afterpay_directdebit", OpenInvoiceDetails.class);
     mappings.put("afterpaytouch", AfterpayDetails.class);
     mappings.put("afterpaytouch_pos", AfterpayDetails.class);
+    mappings.put("afterpaytouch_US", AfterpayDetails.class);
     mappings.put("alipay", PaymentDetails.class);
     mappings.put("alipay_hk", PaymentDetails.class);
     mappings.put("alipay_hk_wap", PaymentDetails.class);

--- a/src/test/java/com/adyen/serializer/ModelTest.java
+++ b/src/test/java/com/adyen/serializer/ModelTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.adyen.model.checkout.AfterpayDetails;
 import com.adyen.model.checkout.CardDetails;
 import com.adyen.model.checkout.CheckoutPaymentMethod;
 import com.adyen.model.checkout.CreateCheckoutSessionResponse;
@@ -19,6 +20,7 @@ import com.adyen.model.tapi.Result;
 import com.adyen.model.tapi.SaleData;
 import com.adyen.model.tapi.TransactionIDType;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
 import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -369,5 +371,35 @@ public class ModelTest {
   @Test
   public void testTapiEnumFromValueNull() {
     assertNull(Result.fromValue(null));
+  }
+
+  @Test
+  public void testCardDetailsFundingSourceEnumSupportsDefferedDebit() {
+    // Adyen POS terminals can return additionalData.fundingSource = "DEFFERED_DEBIT",
+    // which was previously missing from this enum (issue #1878).
+    assertEquals(
+        CardDetails.FundingSourceEnum.DEFFERED_DEBIT,
+        CardDetails.FundingSourceEnum.fromValue("DEFFERED_DEBIT"));
+  }
+
+  @Test
+  public void testAfterpayDetailsTypeEnumSupportsAfterpaytouchUS() {
+    // The /paymentMethods endpoint can return type "afterpaytouch_US" for
+    // Afterpay/Cash App Afterpay in the US, which was previously missing (issue #1953).
+    assertEquals(
+        AfterpayDetails.TypeEnum.AFTERPAYTOUCH_US,
+        AfterpayDetails.TypeEnum.fromValue("afterpaytouch_US"));
+  }
+
+  @Test
+  public void testCheckoutPaymentMethodDeserializesAfterpaytouchUS() throws IOException {
+    String json = "{\"type\": \"afterpaytouch_US\"}";
+
+    CheckoutPaymentMethod paymentMethod = CheckoutPaymentMethod.fromJson(json);
+
+    assertTrue(paymentMethod.getActualInstance() instanceof AfterpayDetails);
+    assertEquals(
+        AfterpayDetails.TypeEnum.AFTERPAYTOUCH_US,
+        ((AfterpayDetails) paymentMethod.getActualInstance()).getType());
   }
 }


### PR DESCRIPTION
Fixes #1953, fixes #1878.

Both issues have the same root cause: the live API can return values that are missing from the generated enums. Because of that, the values get deserialized as `null` and the actual API value is lost.

The missing values are:

* Checkout `/paymentMethods` can return `afterpaytouch_US` for Afterpay/Cash App Afterpay in the US. This is missing from the `CheckoutPaymentMethod` discriminator mapping and `AfterpayDetails.TypeEnum`.
* POS terminals can return `additionalData.fundingSource = DEFFERED_DEBIT`, which is missing from `CardDetails.FundingSourceEnum`.

As discussed in #1514, unknown enum values are handled by returning `null` with a warning instead of throwing an exception. So these values don't cause a failure, but we still lose useful data when they are returned by the API.

This change adds the missing values so they are correctly deserialized.

### Changes

* Added `afterpaytouch_US` to the `CheckoutPaymentMethod` discriminator mapping.
* Added `AFTERPAYTOUCH_US` to `AfterpayDetails.TypeEnum`.
* Added `DEFFERED_DEBIT` to `CardDetails.FundingSourceEnum`.
* Added tests for `fromValue()` resolution and polymorphic deserialization of a `CheckoutPaymentMethod` payload.

The casing is kept exactly as returned by the API (`afterpaytouch_US` and `DEFFERED_DEBIT`). This follows the decision in #1514 to keep enum matching case-sensitive, as defined by OpenAPI.

### Verification

* `mvn -Dtest=com.adyen.serializer.ModelTest test -Dcheckstyle.skip=true` — 19 tests, 0 failures.
* `mvn test -Dcheckstyle.skip=true -DskipITs` — 634 tests, 0 failures, 0 errors, 4 skips.
* `mvn checkstyle:check` — no new violations.